### PR TITLE
Added configuration to send options (:ssl) to connection

### DIFF
--- a/lib/zendesk/configuration.rb
+++ b/lib/zendesk/configuration.rb
@@ -41,6 +41,12 @@ module Zendesk
     attr_accessor :retry
     # @return [Boolean] Whether to log requests to STDOUT.
     attr_accessor :log
+    # @return [Hash] Client configurations (eg ssh config) to pass to Faraday
+    attr_accessor :client_options
+
+    def initialize
+      @client_options = {}
+    end
 
     # Sets accept and user_agent headers, and url.
     #
@@ -52,7 +58,7 @@ module Zendesk
           :user_agent => "Zendesk API #{Zendesk::VERSION}"
         },
         :url => @url
-      }
+      }.merge(client_options)
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -16,4 +16,9 @@ describe Zendesk::Configuration do
   it "should set user agent header properly" do
     subject.options[:headers][:user_agent].should =~ /Zendesk API/
   end
+
+  it "should merge options with client_options" do
+    subject.client_options = {:ssl => false}
+    subject.options[:ssl].should == false
+  end
 end


### PR DESCRIPTION
In our production setup, I need to pass ssl options to the connection to be able to successfully connect to a https url. 

My proposed fix is to add a client_options hash that is merged with the options passed to Faraday
