### PR TITLE
allow the logger to be configured

### DIFF
--- a/lib/zendesk/configuration.rb
+++ b/lib/zendesk/configuration.rb
@@ -24,7 +24,6 @@ module Zendesk
 
       # Turns nil -> false, does nothing to true
       client.config.retry = !!client.config.retry
-      client.config.log = !!client.config.log
 
       client
     end
@@ -39,8 +38,8 @@ module Zendesk
     attr_accessor :url
     # @return [Boolean] Whether to attempt to retry when rate-limited (http status: 429).
     attr_accessor :retry
-    # @return [Boolean] Whether to log requests to STDOUT.
-    attr_accessor :log
+    # @return [Logger] Logger to use when logging requests.
+    attr_accessor :logger
     # @return [Hash] Client configurations (eg ssh config) to pass to Faraday
     attr_accessor :client_options
     # @return [Symbol] Faraday adapter

--- a/lib/zendesk/zendesk.rb
+++ b/lib/zendesk/zendesk.rb
@@ -72,7 +72,7 @@ module Zendesk
     #
     # Uses middleware according to configuration options.
     #
-    # Request logger if log is true
+    # Request logger if logger is not nil
     # 
     # Retry middleware if retry is true
     def connection
@@ -82,7 +82,7 @@ module Zendesk
         builder.use Zendesk::Request::UploadMiddleware
         builder.use Faraday::Response::RaiseError
         builder.use Zendesk::Response::CallbackMiddleware, self
-        builder.response :logger if config.log
+        builder.use Faraday::Response::Logger, config.logger if config.logger
 
         builder.request :multipart
         builder.request :json

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ def client
     config.username = "please.change"
     config.password = "me"
     config.url = "https://my.zendesk.com/api/v2"
-    config.log = !!ENV["LOG"]
+    config.logger = Logger.new(STDOUT) if !!ENV["LOG"]
     config.retry = true
   end
 end


### PR DESCRIPTION
Removes `Zendesk::Configuration#log` in favor of `Zendesk::Configuration#logger`
