### PR TITLE
Make ZendeskAPI::Client subclassable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ Configuration is done through a block returning an instance of ZendeskAPI::Clien
 The block is mandatory and if not passed, a ZendeskAPI::ConfigurationException will be thrown.
 
 ```
-ZendeskAPI.configure do |config|
+ZendeskAPI::Client.new do |config|
   # Mandatory:
 
   # Must be https URL unless config.dont_enforce_https is set

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -1,39 +1,4 @@
 module ZendeskAPI
-  # Raised if a block is not passed to {ZendeskAPI.configure} or if that configuration
-  # does not then pass the constraints.
-  class ConfigurationException < Exception; end
-
-  class << self
-
-    # Takes a block, yields a new {Configuration} instance, then returns a new {Client} instance.
-    #
-    #
-    # Does basic configuration constraints:
-    # * {Configuration#url} must be https unless {Configuration#dont_enforce_https} is set.
-    #
-    # @return [Client] {Client} instance with given configuration options
-    def configure
-      raise ConfigurationException.new("must pass block") unless block_given?
-
-      client = ZendeskAPI::Client.new
-      yield client.config
-
-      if !client.config.dont_enforce_https && client.config.url !~ /^https/
-        raise ConfigurationException.new('zendesk_api is ssl only; url must begin with https://')
-      end
-
-      client.config.retry = !!client.config.retry # nil -> false
-
-      if client.config.logger.nil? || client.config.logger == true
-        require 'logger'
-        client.config.logger = Logger.new($stderr)
-        client.config.logger.level = Logger::WARN
-      end
-
-      client
-    end
-  end
-
   class Configuration
     # @return [String] The basic auth username.
     attr_accessor :username

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe ZendeskAPI::Client do
   subject { client }
 
-  context "#configure" do
+  context "#initialize" do
     it "should require a block" do
-      expect { ZendeskAPI.configure }.to raise_error(ZendeskAPI::ConfigurationException)
+      expect { ZendeskAPI::Client.new }.to raise_error(ArgumentError)
     end
 
     it "should raise an exception when url isn't ssl" do
       expect do
-        ZendeskAPI.configure do |config|
+        ZendeskAPI::Client.new do |config|
           config.url = "http://www.google.com"
         end
-      end.to raise_error(ZendeskAPI::ConfigurationException) 
+      end.to raise_error(ArgumentError) 
     end
 
     it "should not raise an exception when url isn't ssl and dont_enforce_https is set to true" do
       expect do
-        ZendeskAPI.configure do |config|
+        ZendeskAPI::Client.new do |config|
           config.dont_enforce_https = true
           config.url = "http://www.google.com/"
         end
@@ -27,7 +27,7 @@ describe ZendeskAPI::Client do
 
     it "should handle valid url" do
       expect do
-        ZendeskAPI.configure do |config|
+        ZendeskAPI::Client.new do |config|
           config.url = "https://example.zendesk.com/"
         end.to_not raise_error
       end
@@ -35,7 +35,7 @@ describe ZendeskAPI::Client do
 
     context "#logger" do
       before(:each) do
-        @client = ZendeskAPI.configure do |config| 
+        @client = ZendeskAPI::Client.new do |config| 
           config.url = "https://example.zendesk.com/"
           config.logger = subject
         end

--- a/spec/rescue_spec.rb
+++ b/spec/rescue_spec.rb
@@ -38,7 +38,7 @@ describe ZendeskAPI::Rescue do
 
   it "logs to logger" do
     out = StringIO.new
-    client = ZendeskAPI.configure do |config|
+    client = ZendeskAPI::Client.new do |config|
       config.logger = Logger.new(out)
       config.url = "https://idontcare.com"
     end
@@ -47,7 +47,7 @@ describe ZendeskAPI::Rescue do
   end
 
   it "does crash without logger" do
-    client = ZendeskAPI.configure do |config|
+    client = ZendeskAPI::Client.new do |config|
       config.logger = false
       config.url = "https://idontcare.com"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ module TestHelper
   def client
     credentials = File.join(File.dirname(__FILE__), "fixtures", "credentials.yml")
     @client ||= begin
-      client = ZendeskAPI.configure do |config|
+      client = ZendeskAPI::Client.new do |config|
         if File.exist?(credentials)
           data = YAML.load(File.read(credentials))
           config.username = data["username"]


### PR DESCRIPTION
Allow `ZendeskAPI::Client` to be subclassed by moving initializer code from `ZendeskAPI.configure` to `ZendeskAPI::Client#initialize`.

Also have an explicit `config.dont_enforce_https` flag instead of hardcoding exceptions for localhost.

/cc @steved555 @grosser
