### PR TITLE
Only join array values for specific params

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -8,6 +8,8 @@ module ZendeskAPI
   # Represents a collection of resources. Lazily loaded, resources aren't
   # actually fetched until explicitly needed (e.g. #each, {#fetch}).
   class Collection
+    SPECIALLY_JOINED_PARAMS = [:include, :ids, :only]
+
     extend Rescue
 
     # @return [ZendeskAPI::Association] The class association
@@ -29,9 +31,11 @@ module ZendeskAPI
       association_options[:path] ||= @collection_path.join("/") if @collection_path
       @association = @options.delete(:association) || Association.new(association_options.merge(:class => resource))
 
-      # Special case POST topics/show_many
+      # some params use comma-joined strings instead of query-based arrays for multiple values
       @options.each do |k, v|
-        @options[k] = v.join(',') if v.is_a?(Array) 
+        if SPECIALLY_JOINED_PARAMS.include?(k.to_sym) && v.is_a?(Array)
+          @options[k] = v.join(',')
+        end
       end
 
       @collection_path ||= [@resource]


### PR DESCRIPTION
Rack-style query-based array values don't work for API requests; all array values get comma-joined. The server side doesn't accept the comma-joined arrays for all params. I was only able to find cases for `ids`, `include`, and `only`.

Support for query-based array values is required to do `api_client.users(:role => [2,4])`. The choices were to either add support for comma-joined values for all params that can be arrays _in the server_, or to supply query-based array values in the client. I opted to patch the client.

If this patch makes sense, please add some tests to both client and server, and merge to master.

/cc @steved555 @grosser 
