### PR TITLE
Don't require rubygems or bundler in lib

### DIFF
--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -1,5 +1,3 @@
-require "rubygems"
-require "bundler/setup"
 
 require 'zendesk_api/core_ext/modulize'
 require 'zendesk_api/core_ext/snakecase'


### PR DESCRIPTION
These shouldn't be required in the lib.  Rubygems and Bundler should already be setup
before the lib is required (if being used).

See http://www.rubyinside.com/why-using-require-rubygems-is-wrong-1478.html for rationale
