### PR TITLE
More semantic form for token authentication

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -127,7 +127,11 @@ module ZendeskAPI
     def build_connection
       Faraday.new(config.options) do |builder|
         # response
-        builder.use Faraday::Request::BasicAuthentication, config.username, config.password
+        if config.password == nil && config.token != nil
+          builder.use Faraday::Request::BasicAuthentication, "#{config.username}/token", config.token
+        else  
+          builder.use Faraday::Request::BasicAuthentication, config.username, config.password
+        end
         builder.use Faraday::Response::RaiseError
         builder.use ZendeskAPI::Middleware::Response::Callback, self
         builder.use Faraday::Response::Logger, config.logger if config.logger

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -5,6 +5,9 @@ module ZendeskAPI
 
     # @return [String] The basic auth password.
     attr_accessor :password
+    
+    # @return [String] The authorization token. Must be set if password is nil.
+    attr_accessor :token
 
     # @return [String] The API url. Must be https unless {#allow_http} is set.
     attr_accessor :url


### PR DESCRIPTION
allows you to set config.token in place of config.password, abstracting away the "#{username}/token" syntax from the end user
