### PR TITLE
attempt to store error messaging on the resource

### DIFF
--- a/lib/zendesk_api/rescue.rb
+++ b/lib/zendesk_api/rescue.rb
@@ -18,14 +18,10 @@ module ZendeskAPI
       end
 
       def attach_error(e)
-        return false unless e.response && body = e.response[:body]
-        begin
-          self.error_name = body['error']
-          self.error_description = body['description']
-          self.error_details = body['details']
-          true
-        rescue NoMethodError
-          false
+        if error = e.response.try(:[], :body) 
+          error = Hashie::Mash.new(error)
+          self.error = error if respond_to?("error=")            
+          self.error_message = (error.error || error.description) if respond_to?("error_message=")
         end
       end
 

--- a/lib/zendesk_api/resource.rb
+++ b/lib/zendesk_api/resource.rb
@@ -114,6 +114,7 @@ module ZendeskAPI
 
   # Indexable resource
   class DataResource < Data
+    attr_accessor :error, :error_message
     extend Verbs
   end
 


### PR DESCRIPTION
Add API errors to a resource (if possible).  Interested to hear if you have different ideas on the naming or structure.  Right now I'm adding:

error_name
error_description
error_details

This is useful for passing error info to a user in a way similar to ActiveModel::Errors messages.
