### PR TITLE
Avoid clashing with Hashie::Mash#size and an API resource size

### DIFF
--- a/lib/zendesk_api/trackie.rb
+++ b/lib/zendesk_api/trackie.rb
@@ -5,5 +5,10 @@ module ZendeskAPI
   # @private
   class Trackie < Hashie::Mash
     include ZendeskAPI::TrackChanges
+
+    def size
+      self['size']
+    end
+
   end
 end

--- a/spec/core/trackie_spec.rb
+++ b/spec/core/trackie_spec.rb
@@ -36,4 +36,14 @@ describe ZendeskAPI::Trackie do
       subject.changed?.should be_true
     end
   end
+
+  describe "#size" do
+    before do
+      subject[:size] = 42
+    end
+
+    it "returns the value corresponding to the :size key" do
+      subject.size.should == 42
+    end
+  end
 end


### PR DESCRIPTION
When asking the size of a file via API the gem returns the size of the keys representing the resource.

Example. Given an api_attachment.

``` ruby
#<ZendeskAPI::Attachment {
"url"=>"http://example.test/api/v2/attachments/10121.json", 
"id"=>10121,
"file_name"=>"cat.png", 
"size"=>2698,
"content_type"=>"image/png"
}>
```

Calling api_attachment.size will return 5 instead of 2698

5 is because:

``` ruby
["url", "id", "file_name", "size",  "content_type"].size = 5
```

(close HC-721)
