### PR TITLE
Newly initialized User shouldn't be dirty

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -335,7 +335,10 @@ module ZendeskAPI
       super
 
       # Needed for side-loading to work
-      self.role_id = role.id if self.key?(:role)
+      if self.key?(:role)
+        self.role_id = role.id
+        @attributes.clear_changes unless new_record?
+      end
     end
 
     has Organization


### PR DESCRIPTION
Before this change, a newly instantiated User object would always have a changed `role_id` attribute. Trying to use this User to update e.g. the `name` attribute would cause the `role_id` to be sent along as an update as well. Since that attribute isn't allowed for change in Zendesk, the request would fail.

I found no existing spec for this behaviour, and didn't add one.

cc/ @jlauemoeller, @jespr, @steved555
