### PR TITLE
Setting an identical value don't constitute a change

### DIFF
--- a/lib/zendesk_api/track_changes.rb
+++ b/lib/zendesk_api/track_changes.rb
@@ -41,8 +41,12 @@ module ZendeskAPI
       end
 
       def regular_writer(key, value)
-        changes[key] = value
-        defined?(_store) ? _store(key, value) : super(key, value)
+        if self.has_key?(key) && self[key] == value
+          value
+        else
+          changes[key] = value
+          defined?(_store) ? _store(key, value) : super(key, value)
+        end
       end
 
       def delete(key)

--- a/spec/core/trackie_spec.rb
+++ b/spec/core/trackie_spec.rb
@@ -9,7 +9,7 @@ describe ZendeskAPI::Trackie do
   end
 
   context "adding keys" do
-    before(:each) { subject[:key] = true } 
+    before(:each) { subject[:key] = true }
 
     it "should include key in changes" do
       subject.changes[:key].should be_true
@@ -18,6 +18,24 @@ describe ZendeskAPI::Trackie do
     specify "key should be changed" do
       subject.changed?(:key).should be_true
       subject.changed?.should be_true
+    end
+  end
+
+  context "adding identical keys" do
+    before(:each) do
+      subject[:key] = "foo"
+      subject.clear_changes
+
+      subject[:key] = "foo"
+    end
+
+    it "should not include key in changes" do
+      subject.changes[:key].should be_false
+    end
+
+    specify "key should not be changed" do
+      subject.changed?(:key).should be_false
+      subject.changed?.should be_false
     end
   end
 


### PR DESCRIPTION
Telling a Trackie instance `x = Trackie.new(a: "foo")` that `x[:a] = "foo"` would mark it as `changed?`. Thus, when using this Trackie to send an update request, this changed/unchanged attribute would be sent along as an update as well, causing the request to fail if the attribute isn't allowed by Zendesk.

I'm not entirely sure why/where/when the Trackie is being set with identical values, but it is definitely causing problems :-)

cc/ @jlauemoeller, @jespr, @steved555
