### PR TITLE
Support for tags resource

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -26,6 +26,7 @@ module ZendeskAPI
   class Group < Resource; end
   class SharingAgreement < ReadResource; end
   class JobStatus < ReadResource; end
+  class Tag < Resource; end
 
   class Attachment < Data
     def initialize(client, attributes)

--- a/spec/live/tag_spec.rb
+++ b/spec/live/tag_spec.rb
@@ -1,0 +1,13 @@
+require 'core/spec_helper'
+raise "boop"
+describe ZendeskAPI::Tag, :delete_after do
+  # def valid_attributes
+  #   { :name => "My Forum", :forum_type => "articles", :access => "logged-in users", :category_id => category.id }
+  # end
+
+  # it_should_be_creatable
+  # it_should_be_updatable :name
+  # # Forum delete jobs are queued, so don't look for it
+  # it_should_be_deletable :find => false
+  it_should_be_readable :tags, :create => true
+end


### PR DESCRIPTION
This is conversation starter, rather than finished code.

I would like to be able to use the gem to access the [Tags resource](http://developer.zendesk.com/documentation/rest_api/tags.html). I would like to contribute a fix for this, however I'm not sure about what I should test, etc.

I'm assuming that I wouldn't be able to run the "live" specs locally - would I need Zendesk-internal systems?
