### PR TITLE
Do not manipulate r-value of assignment

### DIFF
--- a/lib/zendesk_api/associations.rb
+++ b/lib/zendesk_api/associations.rb
@@ -195,8 +195,8 @@ module ZendeskAPI
         def define_has_many_setter(association)
           define_method "#{association[:name]}=" do |resources|
             if resources.is_a?(Array)
-              resources.map! { |attr| wrap_resource(attr, association) }
-              send(association[:name]).replace(resources)
+              wrapped = resources.map { |attr| wrap_resource(attr, association) }
+              send(association[:name]).replace(wrapped)
             else
               resources.association = Association.new(association.merge(:parent => self))
               instance_variable_set("@#{association[:name]}", resources)

--- a/spec/core/association_spec.rb
+++ b/spec/core/association_spec.rb
@@ -101,6 +101,13 @@ describe ZendeskAPI::Association do
         instance.children.should be_instance_of(ZendeskAPI::Collection)
       end
 
+      it "should not change objects" do
+        child = 'foo'
+        children = [child]
+        instance.children = children
+        children[0].should == 'foo'
+      end
+
       it "is not used when not used" do
         instance.children_used?.should == false
       end


### PR DESCRIPTION
Assignment operation should not change the r-value.

Replacing elements in given arrays will introduce unexpected behaviors like this:

``` ruby
new_tags = %w(a b c)
tags.map(&:to_sym)
# => [:a, :b, :c]

org.tags = new_tags

tags
# => [#<ZendeskAPI::Tag {"id"=>"a"}>, #<ZendeskAPI::Tag {"id"=>"b"}>, #<ZendeskAPI::Tag {"id"=>"c"}>]

tags.map(&:to_sym)
# => [nil, nil, nil]
```
