### PR TITLE
Add save status check

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -602,7 +602,7 @@ module ZendeskAPI
         body = response.body
 
         retry_count -= 1
-        sleep(body["retry_in"])
+        sleep(body["retry_in"] || 3)
 
         break if retry_count <= 0
       end


### PR DESCRIPTION
:koala: :+1: 

---

_Note: job statuses are currently not supported, so you must manually poll the job status API for app creation._

``` ruby
body = {}
until %w{failed completed}.include?(body["status"])
  response = client.connection.get(app.response.headers["Location"])
  body = response.body

  sleep(body["retry_in"])
end
```

---

^ From README

This PR intends to officially add support to status checking

/cc @zendesk/quokka 
