### PR TITLE
[VOICE-1310] rename address resource

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -578,7 +578,7 @@ module ZendeskAPI
       namespace "channels/voice"
     end
 
-    class Address < Resource
+    class CertificationAddress < Resource
       namespace "channels/voice"
     end
 

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -240,7 +240,7 @@ describe ZendeskAPI::Client do
     end
 
     it "manages namespace correctly" do
-      client.addresses.path.should match(/channels\/voice\/addresses/)
+      client.certification_addresses.path.should match(/channels\/voice\/certification_addresses/)
       client.phone_numbers.path.should match(/channels\/voice\/phone_numbers/)
       client.greetings.path.should match(/channels\/voice\/greetings/)
       client.greeting_categories.path.should match(/channels\/voice\/greeting_categories/)


### PR DESCRIPTION
:phone::feet:

/cc @scott2211 @steved555 
### Description

The name of the address resource, which was added here https://github.com/zendesk/zendesk_api_client_rb/commit/76b7abc9ace8fb14c080dad209a1c0b59ccd54da was causing conflicts with the address model in classic. 

This PR renames the resource to a less generic name.
### Steps to merge
- [ ] :+1: of the team
### References
- Jira link: https://zendesk.atlassian.net/browse/VOICE-1310
