### PR TITLE
Use an explicit DataNamespace mixin

### DIFF
--- a/lib/zendesk_api/association.rb
+++ b/lib/zendesk_api/association.rb
@@ -34,7 +34,8 @@ module ZendeskAPI
       namespace = @options[:class].to_s.split("::")
       namespace[-1] = @options[:class].resource_path
 
-      %w(ZendeskAPI Voice).each { |ns| namespace.delete(ns) }
+      # Remove components without path information
+      ignorable_namespace_strings.each { |ns| namespace.delete(ns) }
       has_parent = namespace.size > 1 || (options[:with_parent] && @options.parent)
 
       if has_parent
@@ -70,6 +71,11 @@ module ZendeskAPI
     end
 
     private
+
+    # @return [Array<String>] ['ZendeskAPI', 'Voice', etc.. ]
+    def ignorable_namespace_strings
+      ZendeskAPI::DataNamespace.descendants.map { |klass| klass.to_s.split('::') }.flatten.uniq
+    end
 
     def _side_load(resource, side_loads)
       side_loads.map! do |side_load|

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -171,13 +171,17 @@ module ZendeskAPI
     private
 
     def class_from_namespace(klass_as_const)
-      [ZendeskAPI, ZendeskAPI::Voice].each do |ns|
+      namespaces.each do |ns|
         if ns.const_defined?(klass_as_const)
           return ns.const_get(klass_as_const)
         end
       end
 
       nil
+    end
+
+    def namespaces
+      [ZendeskAPI] + ZendeskAPI::DataNamespace.descendants
     end
 
     def method_as_class(method)

--- a/lib/zendesk_api/resource.rb
+++ b/lib/zendesk_api/resource.rb
@@ -179,4 +179,17 @@ module ZendeskAPI
       { self.class.resource_name.to_sym => attributes.changes }
     end
   end
+
+  # Namespace parent class for Data/Resource classes
+  module DataNamespace
+    class << self
+      def included(base)
+        @descendants ||= []
+        @descendants << base
+      end
+      def descendants
+        @descendants || []
+      end
+    end
+  end
 end

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -603,7 +603,8 @@ module ZendeskAPI
 
   class Target < Resource; end
 
-  module Voice
+  class Voice
+    include DataNamespace
     class PhoneNumber < Resource
       namespace "channels/voice"
     end

--- a/spec/core/data_namespace_spec.rb
+++ b/spec/core/data_namespace_spec.rb
@@ -1,0 +1,15 @@
+require 'core/spec_helper'
+
+class ZendeskAPI::DataNamespaceTest; end
+
+describe ZendeskAPI::DataNamespace do
+  describe "descendants" do
+    let(:target_klass) { ZendeskAPI::DataNamespaceTest }
+    it "adds class to its descendants list when included" do
+      expect(ZendeskAPI::DataNamespace.descendants).not_to include(target_klass)
+      expect { target_klass.send(:include, ZendeskAPI::DataNamespace) }.
+        to change { ZendeskAPI::DataNamespace.descendants.count }.by(1)
+      expect(ZendeskAPI::DataNamespace.descendants).to include(target_klass)
+    end
+  end
+end


### PR DESCRIPTION
Currently there is only the "Voice" namespace used in the public gem. References to this namespace are hard coded in the client (for resolving `client.phone_numbers` type queries) and path building (to deal with nested resources). If we want to add extra namespaces, especially internally, it requires manually updating these two hard-coded lists. By making Data namespaces explicit by using a polymorphic class instead of a module, we have an implicit registry of namespaces available to us. It also allows for future behavior changes, such as specifying path components in the DataNamespace directly instead of in the Resource via `namespace` call.

/cc @steved555 @osheroff @yadavsaroj 
