### PR TITLE
Enable end users to upload files through the Request resource

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -290,9 +290,18 @@ module ZendeskAPI
   end
 
   class Request < Resource
-    class Comment < ReadResource
-      has_many Attachment, :inline => true
+    class Comment < DataResource
+      include Save
+      
+      has_many :uploads, :class => Attachment, :inline => true
       has :author, :class => User
+      
+      def save
+        save_associations
+        true
+      end
+
+      alias :save! :save
     end
 
     has_many Comment


### PR DESCRIPTION
Hi,

We are integrating our web interface with Zendesk and I didn't find a way to include files in a comment using the Request resource as an end user. I modified the Comment class to include this functionality, I don't know if I'm missing anything or if this is the right way to achieve this.

With this change I can upload files as follows:

``` ruby
comment = ZendeskAPI::Request::Comment.new(client, {
  :value => "My logs"
  })
comment.uploads << "/path/to/the/logs"
comment.save!

request.comment = comment
request.save!
```
