### PR TITLE
set a default open_timeout of 10 seconds

### DIFF
--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -55,6 +55,9 @@ module ZendeskAPI
           :accept_encoding => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           :user_agent => "ZendeskAPI API #{ZendeskAPI::VERSION}"
         },
+        :request => {
+          :open_timeout => 10
+        },
         :url => @url
       }.merge(client_options)
     end

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -17,6 +17,10 @@ describe ZendeskAPI::Configuration do
     expect(subject.options[:headers][:user_agent]).to match(/ZendeskAPI API/)
   end
 
+  it "should set a default open_timeout" do
+    expect(subject.options[:request][:open_timeout]).to eq(10)
+  end
+
   it "should merge options with client_options" do
     subject.client_options = {:ssl => false}
     expect(subject.options[:ssl]).to eq(false)


### PR DESCRIPTION
Currently we don't set a default open_timeout, and rely on the default timeouts specified by each client adapter. The default client adapter, Net::HTTP, [has a nil an `open_timeout` value](http://ruby-doc.org/stdlib-2.2.0/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout), which can cause a request to block indefinitely if network traffic is dropped. This can cause a serious issues in background services or workers. I'd expect a small number of our users are manually configuring this value until they run into an issue. It would be helpful to automatically work around issues like #176 by default.

Adapter-wise, `open_timeout` is used by all the Faraday adapters. Here's a run down of the default open_timeout values in the available clients:

- excon: `:connect_timeout      => 60` https://github.com/excon/excon/blob/25117b214e5f0464e894549585dc9bdaad039730/lib/excon/constants.rb#L113
- typhoeus: connecttimeout of 300 seconds via curl https://github.com/typhoeus/typhoeus#readme / http://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html
- patron: `@connect_timeout = 1` https://github.com/toland/patron/blob/2b72d0c3934fba6a197869dda392dce8c1feca49/lib/patron/session.rb#L39-L40
- httpclient: `@connect_timeout = 60` https://github.com/nahi/httpclient/blob/45b1045976d3a09b6491c69668491295c2f6ff08/lib/httpclient/session.rb#L133
- em-http-request: `@connect_timeout     = options[:connect_timeout] || 5` https://github.com/igrigorik/em-http-request/blob/f3e64c01cb7f3039e2309cbb165a83e98b87af5e/lib/em-http/http_connection_options.rb#L6 / https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts

10 seconds seems like a conservative but reasonable default. It fits within a standard unicorn timeout of 25-30 seconds, but isn't too aggressive to interfere with things like 5 second DNS timeouts.

/cc @steved555 

### Risks

This will change the timeouts for users that have manually configured an alternate adapter without an explicit open_timeout. The new values should be reasonably high for even for very janky networks. Manual configuration of timeouts is still possible.