### PR TITLE
Rename CertificationAddress into Address in Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Please check out the [wiki](https://github.com/zendesk/zendesk_api_client_rb/wik
 * Version 1.3.8 had a bug where attachments were created, but the response was not handled properly
 * Version >= 1.0 and < 1.4.2 had a bug where non application/json response bodies were discarded
 * Version 1.5.0 removed support for Ruby 1.8
+* Version 1.6.0 ZendeskAPI::Voice::CertificationAddress is now ZendeskAPI::Voice::Address
 
 ## Installation
 

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -684,7 +684,7 @@ module ZendeskAPI
       namespace "channels/voice"
     end
 
-    class CertificationAddress < Resource
+    class Address < Resource
       namespace "channels/voice"
     end
 

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -271,7 +271,7 @@ describe ZendeskAPI::Client do
     end
 
     it "manages namespace correctly" do
-      expect(client.certification_addresses.path).to match(/channels\/voice\/certification_addresses/)
+      expect(client.addresses.path).to match(/channels\/voice\/addresses/)
       expect(client.phone_numbers.path).to match(/channels\/voice\/phone_numbers/)
       expect(client.greetings.path).to match(/channels\/voice\/greetings/)
       expect(client.greeting_categories.path).to match(/channels\/voice\/greeting_categories/)


### PR DESCRIPTION
@zendesk/mongooses

@ggrossman Since this is public we'll keep the endpoint for a while but we plan to remove it.
There's no documentation in our developer portal for the endpoint and you wouldn't know that you can use this resource unless you dug in the source code. How long do you think that we need to maintain the endpoint?