### PR TITLE
Capture error messages in 413 responses

### DIFF
--- a/lib/zendesk_api/middleware/response/raise_error.rb
+++ b/lib/zendesk_api/middleware/response/raise_error.rb
@@ -15,7 +15,7 @@ module ZendeskAPI
           case env[:status]
           when 404
             raise Error::RecordNotFound.new(env)
-          when 422
+          when 422, 413
             raise Error::RecordInvalid.new(env)
           when 400...600
             raise Error::NetworkError.new(env)

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -70,6 +70,29 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
       end
     end
 
+    context "with status = 413" do
+      let(:status) { 413 }
+
+      it "should raise RecordInvalid" do
+        expect { client.connection.get "/non_existent" }.to raise_error(ZendeskAPI::Error::RecordInvalid)
+      end
+
+      context "with a body" do
+        let(:body) { MultiJson.dump(:details => "big file is big") }
+
+        it "should return RecordInvalid with proper message" do
+          begin
+            client.connection.get "/non_existent"
+          rescue ZendeskAPI::Error::RecordInvalid => e
+            expect(e.errors).to eq("big file is big")
+            expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big")
+          else
+            fail # didn't raise an error
+          end
+        end
+      end
+    end
+
     context "with status = 200" do
       let(:status) { 200 }
 


### PR DESCRIPTION
Since https://github.com/zendesk/zendesk/pull/15158 was deployed, uploads that exceed a plan's maximum file size fail with `413` instead of `422`. Ideally we'd be able to capture the nice, internationalized errors in these responses like we did when they were still returning `422`s.

Alternatively, we could add a new error class specifically for the new response code. I am not sure which option is preferable here.

/cc @steved, @ggrossman 