### PR TITLE
Fix logic in _all so incremental exports don't infinitely loop

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -320,7 +320,7 @@ module ZendeskAPI
       page(start_page)
       clear_cache
 
-      while (bang ? fetch! : fetch) && !empty?
+      while (bang ? fetch! : fetch)
         each do |resource|
           arguments = [resource, @options["page"] || 1]
 
@@ -331,7 +331,7 @@ module ZendeskAPI
           block.call(*arguments)
         end
 
-        self.next
+        last_page? ? break : self.next
       end
 
       page(nil)


### PR DESCRIPTION
When trying to enumerate an incremental_export, the `all!` method will loop continuously until the Zendesk API returns a **429** error. This commit fixes that issue. You can replicate the problem on the current master branch with the following code:

```ruby
ZendeskAPI::User.incremental_export(zdclient, 0).all! {|u|
  puts "User: #{u.id}, #{u.name}"
}
```

There is still an issue of infinitely looping when trying to use the `per_page` method that this commit does not address and it does not look like that is as easy of a fix. It might be best just to advise people not to use `per_page` with the `incremental_export` methods since they don't support a **per_page** parameter.