### PR TITLE
destroy_many uses a comma separated list of ids

### DIFF
--- a/lib/zendesk_api/actions.rb
+++ b/lib/zendesk_api/actions.rb
@@ -220,7 +220,7 @@ module ZendeskAPI
   module DestroyMany
     def destroy_many!(client, ids, association = Association.new(:class => self))
       response = client.connection.delete("#{association.generate_path}/destroy_many") do |req|
-        req.params = { :ids => ids }
+        req.params = { :ids => ids.join(',') }
 
         yield req if block_given?
       end

--- a/spec/core/bulk_actions_spec.rb
+++ b/spec/core/bulk_actions_spec.rb
@@ -10,7 +10,7 @@ describe ZendeskAPI::DestroyMany do
     end
 
     it 'calls the destroy_many endpoint' do
-      assert_requested(:delete, %r{bulk_test_resources/destroy_many\?ids%5B%5D=1&ids%5B%5D=2&ids%5B%5D=3})
+      assert_requested(:delete, %r{bulk_test_resources/destroy_many\?ids=1,2,3$})
     end
 
     it 'returns a JobStatus' do

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -39,7 +39,7 @@ describe ZendeskAPI::Collection do
       collection = ZendeskAPI::Collection.new(client, ZendeskAPI::BulkTestResource)
       stub_json_request(:delete, %r{bulk_test_resources/destroy_many\?}, json(:job_status => {}))
       collection.destroy_many!([1,2,3])
-      assert_requested(:delete, %r{bulk_test_resources/destroy_many\?ids%5B%5D=1&ids%5B%5D=2&ids%5B%5D=3$})
+      assert_requested(:delete, %r{bulk_test_resources/destroy_many\?ids=1,2,3$})
     end
 
     it "should defer #create to the resource class" do


### PR DESCRIPTION
destroy_many uses a comma separated list of ids

/cc @zendesk/octo @steved @aghassipour 

### Risks
 - None