### PR TITLE
Get RecordInvalid message from description in absence of details

### DIFF
--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -10,11 +10,11 @@ module ZendeskAPI
       def initialize(response)
         @response = response
 
-        if response[:body].is_a?(Hash) && response[:body].key?("details")
-          @errors = response[:body]["details"]
-        else
-          @errors = {}
+        if response[:body].is_a?(Hash)
+          @errors = response[:body]["details"] || response[:body]["description"]
         end
+
+        @errors ||= {}
       end
 
       def to_s

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -102,7 +102,7 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
       end
 
       context "with a body" do
-        let(:body) { JSON.dump(:details => "big file is big") }
+        let(:body) { JSON.dump(:description => "big file is big") }
 
         it "should return RecordInvalid with proper message" do
           begin


### PR DESCRIPTION
I found out that even after https://github.com/zendesk/zendesk_api_client_rb/pull/221 we don't get meaningful error messages for uploads that exceed the maximum size. This is because the structure of an upload's errors hash differs from the typical `RecordInvalid` message. 

This PR adds support for falling back to an error's description if details are missing.

@steved, @ggrossman 