### PR TITLE
Raise an error if job status query fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ until %w{failed completed}.include?(body["status"])
 
   sleep(body["retry_in"])
 end
+raise "Job status query failed. body['message']" if body["status"] == "failed"
 ```
 
 #### Updating Apps


### PR DESCRIPTION
:koala:

Current example of job status query does not throw an error if it fails. This is undesirable since the error does not get addressed.

### Risks
 - None