### PR TITLE
Handling bad utf-8 characters on a response

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -13,6 +13,7 @@ require 'zendesk_api/middleware/request/url_based_access_token'
 require 'zendesk_api/middleware/response/callback'
 require 'zendesk_api/middleware/response/deflate'
 require 'zendesk_api/middleware/response/gzip'
+require 'zendesk_api/middleware/response/sanitize_response'
 require 'zendesk_api/middleware/response/parse_iso_dates'
 require 'zendesk_api/middleware/response/parse_json'
 require 'zendesk_api/middleware/response/raise_error'
@@ -142,6 +143,7 @@ module ZendeskAPI
         builder.use ZendeskAPI::Middleware::Response::Logger, config.logger if config.logger
         builder.use ZendeskAPI::Middleware::Response::ParseIsoDates
         builder.use ZendeskAPI::Middleware::Response::ParseJson
+        builder.use ZendeskAPI::Middleware::Response::SanitizeResponse
 
         adapter = config.adapter || Faraday.default_adapter
 

--- a/lib/zendesk_api/middleware/response/sanitize_response.rb
+++ b/lib/zendesk_api/middleware/response/sanitize_response.rb
@@ -1,0 +1,13 @@
+require 'scrub_rb'
+
+module ZendeskAPI
+  module Middleware
+    module Response
+      class SanitizeResponse < Faraday::Response::Middleware
+        def on_complete(env)
+          env[:body].scrub!('')
+        end
+      end
+    end
+  end
+end

--- a/spec/core/middleware/response/sanitize_response_spec.rb
+++ b/spec/core/middleware/response/sanitize_response_spec.rb
@@ -1,0 +1,19 @@
+require 'core/spec_helper'
+
+describe ZendeskAPI::Middleware::Response::SanitizeResponse do
+  def fake_response(data)
+    stub_json_request(:get, %r{blergh}, data)
+    response = client.connection.get('blergh')
+    expect(response.status).to eq(200)
+    response
+  end
+
+  describe 'with bad characters' do
+    let(:response) { fake_response("{\"x\":\"2012-02-01T13:14:15Z\", \"y\":\"\u0315\u0316\u01333\u0270\u022712awesome!\ud83d\udc4d\"}") }
+
+    it 'removes bad characters' do
+      expect(response.body.to_s.valid_encoding?).to be(true)
+      expect(response.body['y'].to_s).to eq("\u0315\u0316\u01333\u0270\u022712awesome!")
+    end
+  end
+end

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = %q{Ruby wrapper for the REST API at http://www.zendesk.com. Documentation at http://developer.zendesk.com.}
   s.license     = 'Apache License Version 2.0'
 
-  s.required_ruby_version     = ">= 1.9.3"
+  s.required_ruby_version     = ">= 1.9.0"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_development_dependency "bump"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = %q{Ruby wrapper for the REST API at http://www.zendesk.com. Documentation at http://developer.zendesk.com.}
   s.license     = 'Apache License Version 2.0'
 
-  s.required_ruby_version     = ">= 1.9.0"
+  s.required_ruby_version     = ">= 1.9.3"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_development_dependency "bump"
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
   s.add_runtime_dependency "mime-types"
+  s.add_runtime_dependency "scrub_rb", "~> 1.0.1"
 
   s.files              = `git ls-files -x Gemfile.lock`.split("\n") rescue ''
   s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
If a response contains characters with bad UTF-8 characters the ParseIsoDates middleware blows up when doing the Regex. 
This PR is just to allow the client to handle that case.

/cc @henders @steved @grosser 
