### PR TITLE
fix method_as_class to handle non alphanumeric

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -179,7 +179,7 @@ module ZendeskAPI
     private
 
     def method_as_class(method)
-      klass_as_string = ZendeskAPI::Helpers.modulize_string(Inflection.singular(method.to_s))
+      klass_as_string = ZendeskAPI::Helpers.modulize_string(Inflection.singular(method.to_s.gsub(/\W/, '')))
       ZendeskAPI::Association.class_from_namespace(klass_as_string)
     end
 

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -240,6 +240,7 @@ describe ZendeskAPI::Client do
 
     it "should not respond_to? invalid resources" do
       expect(subject.respond_to?(:nope)).to eq(false)
+      expect(subject.respond_to?(:empty?)).to eq(false)
     end
 
     it "delegates voice correctly" do


### PR DESCRIPTION
Hey,

My team had a production bug caused by calling .empty? on a client object.
the client api doesn't handle question marks well so I added this handling.

Also added test. :)
