### PR TITLE
Remove version constraint on mime-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "jruby-openssl", :platforms => :jruby
-gem "mime-types", "~> 2.99", :platforms => :ruby_19
+gem "mime-types", "~> 2.99", :platforms => [:ruby_19, :jruby]
 
 group :test do
   gem "simplecov"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "vcr"
-  s.add_development_dependency "webmock"
+  s.add_development_dependency "webmock", "< 2"
   s.add_development_dependency "yard"
 
   s.add_runtime_dependency "faraday", "~> 0.9"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hashie", ">= 1.2", "< 4.0", "!= 3.3.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
-  s.add_runtime_dependency "mime-types", "~> 2.99"
+  s.add_runtime_dependency "mime-types"
   s.add_runtime_dependency "scrub_rb", "~> 1.0.1"
 end


### PR DESCRIPTION
Clients using Ruby < 2.0 should themselves set a version restriction so they don't install mime-types >= v3.0.