### PR TITLE
Support for unified Integer class in Ruby 2.4+

### DIFF
--- a/lib/zendesk_api/associations.rb
+++ b/lib/zendesk_api/associations.rb
@@ -20,7 +20,7 @@ module ZendeskAPI
       case resource
       when Hash
         klass.new(@client, resource.merge(:association => instance_association))
-      when String, Fixnum
+      when String, Integer
         klass.new(@client, (options[:include_key] || :id) => resource, :association => instance_association)
       else
         resource.association = instance_association


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005