### PR TITLE
Search needs to include query

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -295,7 +295,7 @@ module ZendeskAPI
 
     # Creates a search collection
     def self.search(client, options = {})
-      unless (%w{query external_id} & options.keys.map(&:to_s)).any?
+      unless options.keys.map(&:to_s).include?("query")
         warn "you have not specified a query for this search"
       end
 


### PR DESCRIPTION
To perform successful searches the call to the API needs to include `:query`
while `:external_id` does not seem to work.