### PR TITLE
Remove dependency on scrub_rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rspec"
 gem "rubocop", "0.39.0"
 gem "vcr"
 gem "webmock", "< 2"
+gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"
 gem "json", "< 2.0", :platforms => :ruby_19
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "webmock", "< 2"
 gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"
 gem "json", "< 2.0", :platforms => :ruby_19
+gem "scrub_rb", :platforms => [:ruby_19, :ruby_20, :jruby]
 
 group :test do
   gem "simplecov"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please check out the [wiki](https://github.com/zendesk/zendesk_api_client_rb/wik
 * Version 1.5.0 removed support for Ruby 1.8
 * Version 1.6.0 ZendeskAPI::Voice::CertificationAddress is now ZendeskAPI::Voice::Address
 * Version 1.8.0 no longer considers 1XX and 3XX (except 304) response status codes valid and will raise a NetworkError
+* Version 1.x.x requires you to install `scrub_rb` or `string-scrub` or similar implementation of `String#scrub!` if you're using Ruby 1.9 or 2.0.
 
 ## Installation
 
@@ -38,6 +39,10 @@ Add it to your Gemfile
     gem "zendesk_api"
 
 and follow normal [Bundler](http://gembundler.com/) installation and execution procedures.
+
+If you're using Ruby 1.9 or 2.0, you'll need an implementation of `String#scrub!`. You can use either `scrub_rb` or `string-scrub` or a similar gem to accomplish that:
+
+    gem "scrub_rb"
 
 ## Configuration
 

--- a/lib/zendesk_api/middleware/response/sanitize_response.rb
+++ b/lib/zendesk_api/middleware/response/sanitize_response.rb
@@ -1,5 +1,3 @@
-require 'scrub_rb'
-
 module ZendeskAPI
   module Middleware
     module Response

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -13,6 +13,7 @@ require 'zendesk_api'
 require 'vcr'
 require 'logger'
 require 'stringio'
+require 'scrub_rb' if RUBY_VERSION < "2.1.0"
 
 begin
   require 'byebug'

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
   s.add_runtime_dependency "mime-types"
-  s.add_runtime_dependency "scrub_rb", "~> 1.0.1"
 end


### PR DESCRIPTION
For people using Ruby 2.1 or newer, this gem is dead weight. Let's just document that if you use an old version of Ruby, you need to install a gem that implements `scrub!` for you.