### PR TITLE
show what exactly went wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,7 @@ script:
   - bundle exec rake
   - bundle exec rubocop
 
+branches:
+  only: master
+
 sudo: false

--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -1,14 +1,19 @@
+# tested via spec/core/middleware/response/raise_error_spec.rb
 module ZendeskAPI
   module Error
     class ClientError < Faraday::Error::ClientError
       attr_reader :wrapped_exception
+
+      def to_s
+        "#{super} -- #{response.method} #{response.url}"
+      end
     end
 
     class RecordInvalid < ClientError
-      attr_accessor :response, :errors
+      attr_accessor :errors
 
-      def initialize(response)
-        @response = response
+      def initialize(*)
+        super
 
         if response[:body].is_a?(Hash)
           @errors = response[:body]["details"] || response[:body]["description"]
@@ -18,7 +23,7 @@ module ZendeskAPI
       end
 
       def to_s
-        "#{self.class.name}: #{@errors.to_s}"
+        "#{self.class.name}: #{@errors}"
       end
     end
 

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -66,8 +66,12 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
     context "with status in 3XX" do
       let(:status) { 302 }
 
-      it "should raise NetworkError" do
+      it "raises NetworkError" do
         expect { client.connection.get "/non_existent" }.to raise_error(ZendeskAPI::Error::NetworkError)
+      end
+
+      it "tells the user what was going on" do
+        expect { client.connection.get "/non_existent" }.to raise_error("the server responded with status 302 -- get https://my.zendesk.com/non_existent")
       end
     end
 


### PR DESCRIPTION
Currently getting random errors like: `ZendeskAPI::Error::NetworkError: the server responded with status 500
` ... would be much nicer to receive: `ZendeskAPI::Error::NetworkError: the server responded with status 500 -- get https://fail.zendesk.com/api/v2/incremental/tickets.json?include=users%2Cgroups%2Corganizations%2Cmetric_sets%2Cdates&start_time=1425754064`

@bquorning @vgrigoruk 