### PR TITLE
document hashie dependency

### DIFF
--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "~> 0.9"
-  s.add_runtime_dependency "hashie", ">= 1.2", "< 4.0", "!= 3.3.0"
+  s.add_runtime_dependency "hashie", ">= 3.5.2", "< 4.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
   s.add_runtime_dependency "mime-types"


### PR DESCRIPTION
fixing fallout from https://github.com/zendesk/zendesk_api_client_rb/pull/327

alternatively we could use our own disabled subclass ...

will have to yank v1.14.3 after releasing this or nothing will be fixed

@bquorning @pschambacher 