### PR TITLE
Fix failure spec in master branch

### DIFF
--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -377,17 +377,20 @@ describe ZendeskAPI::Collection do
               @used = true
 
               probe = self
+              callback = @callback
               Proc.new do |arg|
                 probe.num_yields += 1
                 probe.yielded_args << [arg]
+                callback.call([arg])
+                nil
               end
             end
           end
 
           silence_logger { subject.all(&block) }
         end.to yield_successive_args(
-          ZendeskAPI::TestResource.new(client, :id => 1),
-          ZendeskAPI::TestResource.new(client, :id => 2)
+          [ZendeskAPI::TestResource.new(client, :id => 1)],
+          [ZendeskAPI::TestResource.new(client, :id => 2)]
         )
       end
 


### PR DESCRIPTION
Fix failure spec.
`to_proc` is different from RSpec master.
https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers/built_in/yield.rb#L38