### PR TITLE
Use newest bundler in travis CI (Fix travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ rvm:
   - 2.3.0
   - jruby
 
+install:
+  - "gem install bundler"
+  - "bundle install --jobs=3 --retry=3"
+
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ rvm:
   - 2.3.0
   - jruby
 
-install:
+before_install:
   - "gem install bundler"
-  - "bundle install --jobs=3 --retry=3"
 
 script:
   - bundle exec rake


### PR DESCRIPTION
Use newest bundler reported in bundler/bundler#3559

Failure job
https://travis-ci.org/zendesk/zendesk_api_client_rb/jobs/273512217