### PR TITLE
Add option to raise error when rate limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ client = ZendeskAPI::Client.new do |config|
   # then retry the request.
   config.retry = true
 
+  # Raise error when hitting the rate limit.
+  # This is ignored and always set to false when `retry` is enabled.
+  # Disabled by default.
+  config.raise_error_when_rate_limited = false
+
   # Logger prints to STDERR by default, to e.g. print to stdout:
   require 'logger'
   config.logger = Logger.new(STDOUT)

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -8,6 +8,7 @@ require 'zendesk_api/lru_cache'
 require 'zendesk_api/silent_mash'
 require 'zendesk_api/middleware/request/etag_cache'
 require 'zendesk_api/middleware/request/retry'
+require 'zendesk_api/middleware/request/raise_rate_limited'
 require 'zendesk_api/middleware/request/upload'
 require 'zendesk_api/middleware/request/encode_json'
 require 'zendesk_api/middleware/request/url_based_access_token'
@@ -93,6 +94,8 @@ module ZendeskAPI
 
       config.retry = !!config.retry # nil -> false
 
+      set_raise_error_when_rated_limited
+
       set_token_auth
 
       set_default_logger
@@ -171,7 +174,12 @@ module ZendeskAPI
         builder.use ZendeskAPI::Middleware::Request::Upload
         builder.request :multipart
         builder.use ZendeskAPI::Middleware::Request::EncodeJson
-        builder.use ZendeskAPI::Middleware::Request::Retry, :logger => config.logger if config.retry # Should always be first in the stack
+
+        # Should always be first in the stack
+        builder.use ZendeskAPI::Middleware::Request::Retry, :logger => config.logger if config.retry
+        if config.raise_error_when_rate_limited
+          builder.use ZendeskAPI::Middleware::Request::RaiseRateLimited, :logger => config.logger
+        end
 
         builder.adapter(*adapter)
       end
@@ -187,6 +195,14 @@ module ZendeskAPI
     def check_url
       if !config.allow_http && config.url !~ /^https/
         raise ArgumentError, "zendesk_api is ssl only; url must begin with https://"
+      end
+    end
+
+    def set_raise_error_when_rated_limited
+      config.raise_error_when_rate_limited = if config.retry
+        false
+      else
+        !!config.raise_error_when_rate_limited
       end
     end
 

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -16,6 +16,9 @@ module ZendeskAPI
     # @return [Boolean] Whether to attempt to retry when rate-limited (http status: 429).
     attr_accessor :retry
 
+    # @return [Boolean] Whether to raise error when rate-limited (http status: 429).
+    attr_accessor :raise_error_when_rate_limited
+
     # @return [Logger] Logger to use when logging requests.
     attr_accessor :logger
 

--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -33,5 +33,6 @@ module ZendeskAPI
 
     class NetworkError < ClientError; end
     class RecordNotFound < ClientError; end
+    class RateLimited < ClientError; end
   end
 end

--- a/lib/zendesk_api/middleware/request/raise_rate_limited.rb
+++ b/lib/zendesk_api/middleware/request/raise_rate_limited.rb
@@ -1,0 +1,32 @@
+require 'faraday/middleware'
+require 'zendesk_api/error'
+
+module ZendeskAPI
+  module Middleware
+    # @private
+    module Request
+      # Faraday middleware to handle HTTP Status 429 (rate limiting) / 503 (maintenance)
+      # @private
+      class RaiseRateLimited < Faraday::Middleware
+        ERROR_CODES = [429, 503]
+
+        def initialize(app, options = {})
+          super(app)
+          @logger = options[:logger]
+        end
+
+        def call(env)
+          original_env = env.dup
+          response = @app.call(env)
+
+          if ERROR_CODES.include?(response.env[:status])
+            @logger.warn 'You have been rate limited. Raising error...' if @logger
+            raise Error::RateLimited.new(env)
+          else
+            response
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/zendesk_api/middleware/request/raise_rate_limited.rb
+++ b/lib/zendesk_api/middleware/request/raise_rate_limited.rb
@@ -8,7 +8,7 @@ module ZendeskAPI
       # Faraday middleware to handle HTTP Status 429 (rate limiting) / 503 (maintenance)
       # @private
       class RaiseRateLimited < Faraday::Middleware
-        ERROR_CODES = [429, 503]
+        ERROR_CODES = [429, 503].freeze
 
         def initialize(app, options = {})
           super(app)
@@ -16,7 +16,6 @@ module ZendeskAPI
         end
 
         def call(env)
-          original_env = env.dup
           response = @app.call(env)
 
           if ERROR_CODES.include?(response.env[:status])

--- a/spec/core/middleware/request/raise_rate_limited_spec.rb
+++ b/spec/core/middleware/request/raise_rate_limited_spec.rb
@@ -1,0 +1,27 @@
+require 'core/spec_helper'
+
+describe ZendeskAPI::Middleware::Request::RaiseRateLimited do
+  before do
+    client.config.retry = false
+    client.config.raise_error_when_rate_limited = true
+
+    stub_request(:get, %r{blergh}).
+      to_return(status: 429)
+  end
+
+  it 'should raise RateLimited' do
+    expect {
+      client.connection.get('blergh')
+    }.to raise_error(ZendeskAPI::Error::RateLimited)
+  end
+
+  it 'should print to logger' do
+    expect(client.config.logger).to receive(:warn)
+    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited
+  end
+
+  it 'should not fail without a logger', :prevent_logger_changes do
+    client.config.logger = false
+    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited
+  end
+end

--- a/spec/core/middleware/request/raise_rate_limited_spec.rb
+++ b/spec/core/middleware/request/raise_rate_limited_spec.rb
@@ -5,23 +5,23 @@ describe ZendeskAPI::Middleware::Request::RaiseRateLimited do
     client.config.retry = false
     client.config.raise_error_when_rate_limited = true
 
-    stub_request(:get, %r{blergh}).
+    stub_request(:get, /blergh/).
       to_return(status: 429)
   end
 
   it 'should raise RateLimited' do
-    expect {
+    expect do
       client.connection.get('blergh')
-    }.to raise_error(ZendeskAPI::Error::RateLimited)
+    end.to raise_error(ZendeskAPI::Error::RateLimited)
   end
 
   it 'should print to logger' do
     expect(client.config.logger).to receive(:warn)
-    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited
+    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited # rubocop:disable Style/RescueModifier
   end
 
   it 'should not fail without a logger', :prevent_logger_changes do
     client.config.logger = false
-    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited
+    client.connection.get('blergh') rescue ZendeskAPI::Error::RateLimited # rubocop:disable Style/RescueModifier
   end
 end


### PR DESCRIPTION
The motivation of this came from us using Zendesk API as part of background jobs. If we are rate limited, we do not want the job to be hogging the background worker, and instead raise an error and be requeued immediately. This will allow us to handle the error and delay the job for a later time. And also for other jobs to be processed asap.
