### PR TITLE
Log response body on 400 range

### DIFF
--- a/lib/zendesk_api/middleware/response/logger.rb
+++ b/lib/zendesk_api/middleware/response/logger.rb
@@ -18,7 +18,10 @@ module ZendeskAPI
           @logger.debug dump_debug(env, :request_headers)
 
           @app.call(env).on_complete do |env|
-            @logger.info("Status #{env[:status].to_s}")
+            info = "Status #{env[:status].to_s}"
+            info.concat(" #{env[:body].inspect}") if (400..499).include?(env[:status].to_i)
+
+            @logger.info info
             @logger.debug dump_debug(env, :response_headers)
           end
         end

--- a/lib/zendesk_api/middleware/response/logger.rb
+++ b/lib/zendesk_api/middleware/response/logger.rb
@@ -18,7 +18,7 @@ module ZendeskAPI
           @logger.debug dump_debug(env, :request_headers)
 
           @app.call(env).on_complete do |env|
-            info = "Status #{env[:status].to_s}"
+            info = "Status #{env[:status]}"
             info.concat(" #{env[:body].inspect}") if (400..499).cover?(env[:status].to_i)
 
             @logger.info info

--- a/lib/zendesk_api/middleware/response/logger.rb
+++ b/lib/zendesk_api/middleware/response/logger.rb
@@ -4,6 +4,8 @@ module ZendeskAPI
       # Faraday middleware to handle logging
       # @private
       class Logger < Faraday::Middleware
+        LOG_LENGTH = 1000
+
         def initialize(app, logger = nil)
           super(app)
 
@@ -19,7 +21,7 @@ module ZendeskAPI
 
           @app.call(env).on_complete do |env|
             info = "Status #{env[:status]}"
-            info.concat(" #{env[:body].inspect}") if (400..499).cover?(env[:status].to_i)
+            info.concat(" #{env[:body].to_s[0, LOG_LENGTH]}") if (400..499).cover?(env[:status].to_i)
 
             @logger.info info
             @logger.debug dump_debug(env, :response_headers)

--- a/lib/zendesk_api/middleware/response/logger.rb
+++ b/lib/zendesk_api/middleware/response/logger.rb
@@ -19,7 +19,7 @@ module ZendeskAPI
 
           @app.call(env).on_complete do |env|
             info = "Status #{env[:status].to_s}"
-            info.concat(" #{env[:body].inspect}") if (400..499).include?(env[:status].to_i)
+            info.concat(" #{env[:body].inspect}") if (400..499).cover?(env[:status].to_i)
 
             @logger.info info
             @logger.debug dump_debug(env, :response_headers)


### PR DESCRIPTION
Zendesk API returns the response status 400 range and the error messages as its body when the request was not successful.
https://developer.zendesk.com/rest_api/docs/core/introduction#400-range

But the response status is only output to the log now.
So, I would like to suggest to log the response body also to understand why the request was failure.