### PR TITLE
Specify jruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
-  - jruby
+  # Specify jruby versions until rvm/rvm#4210 are resolved
+  - jruby-9.1.9.0
+  - jruby-9.1.10.0
 
 before_install:
   - "gem install bundler"


### PR DESCRIPTION
Travis CI failed to install jruby by using rvm.
This is reported by rvm/rvm#4210.

Specify jruby versions in `.travis.yml` until the problem are resolved.