### PR TITLE
Don't attempt to sideload with empty HTTP response body

### DIFF
--- a/lib/zendesk_api/sideloading.rb
+++ b/lib/zendesk_api/sideloading.rb
@@ -18,6 +18,7 @@ module ZendeskAPI
       resource_class = resources.first.class
 
       return if resources.empty?
+      return if body.empty?
 
       body.keys.each do |name|
         @included[name] = body[name]


### PR DESCRIPTION
Sideloading fails with VCR during tests when attempting to iterate
through keys of an empty response body.