### PR TITLE
ZendeskAPI::Resource: Define respond_to_missing?

### DIFF
--- a/lib/zendesk_api/resource.rb
+++ b/lib/zendesk_api/resource.rb
@@ -81,6 +81,10 @@ module ZendeskAPI
       @attributes.send(*args, &block)
     end
 
+    def respond_to_missing?(method, include_private = false)
+      @attributes.respond_to?(method) || super
+    end
+
     # Returns the resource id of the object or nil
     def id
       key?(:id) ? method_missing(:id) : nil

--- a/spec/core/resource_spec.rb
+++ b/spec/core/resource_spec.rb
@@ -43,6 +43,19 @@ describe ZendeskAPI::Resource do
         end
       end
     end
+
+    context "instance method" do
+      subject(:resource) do
+        ZendeskAPI::TestResource.new(client, :id => 1)
+      end
+
+      it "is delegated to the attributes" do
+        expect(resource.attributes).to receive(:update).and_call_original
+        resource.update(subject: "Hello?")
+      end
+
+      it { is_expected.to respond_to(:update) }
+    end
   end
 
   context "#destroy" do


### PR DESCRIPTION
To accompany the existing `method_missing` method