### PR TITLE
add follow_redirects middleware to base connection object

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday_middleware'
 
 require 'zendesk_api/version'
 require 'zendesk_api/sideloading'
@@ -147,6 +148,7 @@ module ZendeskAPI
         builder.use ZendeskAPI::Middleware::Response::ParseIsoDates
         builder.use ZendeskAPI::Middleware::Response::ParseJson
         builder.use ZendeskAPI::Middleware::Response::SanitizeResponse
+        builder.use FaradayMiddleware::FollowRedirects
 
         adapter = config.adapter || Faraday.default_adapter
 

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "~> 0.9"
+  s.add_runtime_dependency "faraday_middleware", "~> 0.12.2"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 4.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"


### PR DESCRIPTION
fetching an image embedded inside an article (e.g., for local caching)
previously failed due to a redirect.

I wasn't sure how to repro this in a test, but if you have suggestions on where a test would be appropriate to add, I would be willing to add it.