### PR TITLE
Add support to create or update many users and remove unsupported update many users

### DIFF
--- a/lib/zendesk_api/actions.rb
+++ b/lib/zendesk_api/actions.rb
@@ -181,6 +181,26 @@ module ZendeskAPI
     end
   end
 
+  module CreateOrUpdateMany
+    # Creates or updates multiple resources using the create_or_update_many endpoint.
+    #
+    # @param [Client] client The {Client} object to be used
+    # @param [Array<Hash>] attributes The attributes to update resources with
+    #
+    # @return [JobStatus] the {JobStatus} instance for this destroy job
+    def create_or_update_many!(client, attributes)
+      association = Association.new(:class => self)
+
+      response = client.connection.post("#{association.generate_path}/create_or_update_many") do |req|
+        req.body = { resource_name => attributes }
+
+        yield req if block_given?
+      end
+
+      JobStatus.new_from_response(client, response)
+    end
+  end
+
   module Destroy
     def self.included(klass)
       klass.extend(ClassMethod)

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -649,6 +649,7 @@ module ZendeskAPI
 
   class User < Resource
     extend CreateMany
+    extend CreateOrUpdateMany
     extend DestroyMany
 
     class TopicComment < TopicComment

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -649,7 +649,6 @@ module ZendeskAPI
 
   class User < Resource
     extend CreateMany
-    extend UpdateMany
     extend DestroyMany
 
     class TopicComment < TopicComment

--- a/spec/core/bulk_actions_spec.rb
+++ b/spec/core/bulk_actions_spec.rb
@@ -89,3 +89,32 @@ describe ZendeskAPI::CreateMany do
     end
   end
 end
+
+RSpec.describe ZendeskAPI::CreateOrUpdateMany do
+  subject(:resource) { ZendeskAPI::BulkTestResource }
+
+  context "create_or_update_many!" do
+    context "creating or updating with multiple attribute hashes" do
+      let(:attributes) { [{ :id => 1, :name => 'A' }, { :id => 2, :name => 'B' }] }
+
+      subject { resource.create_or_update_many!(client, attributes) }
+
+      before do
+        stub_json_request(:post, %r{bulk_test_resources/create_or_update_many}, json(:job_status => { :id => 'jkl' }))
+      end
+
+      it 'calls the create_or_update_many endpoint' do
+        subject
+
+        assert_requested(:post, %r{bulk_test_resources/create_or_update_many$},
+          :body => json(:bulk_test_resources => attributes)
+        )
+      end
+
+      it 'returns a JobStatus' do
+        expect(subject).to be_a(ZendeskAPI::JobStatus)
+        expect(subject.id).to eq('jkl')
+      end
+    end
+  end
+end

--- a/spec/fixtures/test_resources.rb
+++ b/spec/fixtures/test_resources.rb
@@ -9,6 +9,7 @@ end
 
 class ZendeskAPI::BulkTestResource < ZendeskAPI::DataResource
   extend ZendeskAPI::CreateMany
+  extend ZendeskAPI::CreateOrUpdateMany
   extend ZendeskAPI::DestroyMany
   extend ZendeskAPI::UpdateMany
 end


### PR DESCRIPTION
The API for this is slightly different than the API in `CreateMany` and `UpdateMany` because the endpoint doesn't support the ID-based query parameters.

I did not add a live test because it appears that none of the bulk actions have them.