### PR TITLE
Update Ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6.1
   # Specify jruby versions until rvm/rvm#4210 are resolved
   - jruby-9.1.9.0
   - jruby-9.1.10.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Zendesk API Client
 
+[![Build Status](https://secure.travis-ci.org/zendesk/zendesk_api_client_rb.png?branch=master)](http://travis-ci.org/zendesk/zendesk_api_client_rb)
+[![Gem Version](https://badge.fury.io/rb/zendesk_api.png)](http://badge.fury.io/rb/zendesk_api)
+[![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.png)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
+
 ## API version support
 
 This client **only** supports Zendesk's v2 API.  Please see our [API documentation](http://developer.zendesk.com) for more information.
@@ -39,10 +43,6 @@ Add it to your Gemfile
     gem "zendesk_api"
 
 and follow normal [Bundler](http://gembundler.com/) installation and execution procedures.
-
-If you're using Ruby 1.9 or 2.0, you'll need an implementation of `String#scrub!`. You can use either `scrub_rb` or `string-scrub` or a similar gem to accomplish that:
-
-    gem "scrub_rb"
 
 ## Configuration
 
@@ -412,13 +412,6 @@ ZendeskAPI::AppInstallation.destroy!(client, :id => 123)
    your own version, that is fine but bump version in a commit by itself I can
    ignore when I pull)
 5. Send me a pull request. Bonus points for topic branches.
-
-## Supported Ruby Versions
-
-Tested with Ruby 1.9, 2.0, 2.1, 2.2 and jRuby.
-[![Build Status](https://secure.travis-ci.org/zendesk/zendesk_api_client_rb.png?branch=master)](http://travis-ci.org/zendesk/zendesk_api_client_rb)
-[![Gem Version](https://badge.fury.io/rb/zendesk_api.png)](http://badge.fury.io/rb/zendesk_api)
-[![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.png)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
 
 ## Copyright and license
 

--- a/spec/core/middleware/response/sanitize_response_spec.rb
+++ b/spec/core/middleware/response/sanitize_response_spec.rb
@@ -9,7 +9,7 @@ describe ZendeskAPI::Middleware::Response::SanitizeResponse do
   end
 
   describe 'with bad characters' do
-    let(:response) { fake_response("{\"x\":\"2012-02-01T13:14:15Z\", \"y\":\"\u0315\u0316\u01333\u0270\u022712awesome!\ud83d\udc4d\"}") }
+    let(:response) { fake_response("{\"x\":\"2012-02-01T13:14:15Z\", \"y\":\"\u0315\u0316\u01333\u0270\u022712awesome!"+[0xd83d,0xdc4d].pack('U*')+"\"}") }
 
     it 'removes bad characters' do
       expect(response.body.to_s.valid_encoding?).to be(true)

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,util}/**/*')
 
-  s.required_ruby_version     = ">= 1.9.0"
+  s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "~> 0.9"


### PR DESCRIPTION
Goal: Get Travis-CI builds functional again for this repo.

* Drop Travis-CI runs for Ruby versions < 2.3, which are now EOL
* Add Ruby 2.4, 2.5, and 2.6 to Travis-CI test matrix
* Fix sanitize_response_spec to work for Ruby >= 2.4. Invalid Unicode code points are no longer accepted for `\uXXXX` sequences.