### PR TITLE
Update ticket incremental export endpoint

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -465,7 +465,7 @@ module ZendeskAPI
     # @param [Integer] start_time The start_time parameter
     # @return [Collection] Collection of {Ticket}
     def self.incremental_export(client, start_time)
-      ZendeskAPI::Collection.new(client, self, :path => "exports/tickets?start_time=#{start_time.to_i}")
+      ZendeskAPI::Collection.new(client, self, :path => "incremental/tickets?start_time=#{start_time.to_i}")
     end
 
     # Imports a ticket through the imports/tickets endpoint using save!

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -302,18 +302,18 @@ describe ZendeskAPI::Collection do
 
     context "incremental requests" do
       subject do
-        ZendeskAPI::Collection.new(client, ZendeskAPI::TestResource, :path => 'exports/test_resources?start_time=0')
+        ZendeskAPI::Collection.new(client, ZendeskAPI::TestResource, :path => 'incremental/test_resources?start_time=0')
       end
 
       before(:each) do
-        stub_json_request(:get, %r{exports/test_resources\?start_time=0$}, json(
+        stub_json_request(:get, %r{incremental/test_resources\?start_time=0$}, json(
           :test_resources => [{ :id => 1 }],
-          :next_page => "/exports/test_resources?start_time=200"
+          :next_page => "/incremental/test_resources?start_time=200"
         ))
 
-        stub_json_request(:get, %r{exports/test_resources\?start_time=200$}, json(
+        stub_json_request(:get, %r{incremental/test_resources\?start_time=200$}, json(
           :test_resources => [{ :id => 2 }],
-          :next_page => "/exports/test_resources?start_time=200"
+          :next_page => "/incremental/test_resources?start_time=200"
         ))
       end
 

--- a/spec/live/ticket_spec.rb
+++ b/spec/live/ticket_spec.rb
@@ -54,7 +54,7 @@ describe ZendeskAPI::Ticket do
 
     it "is able to do next" do
       first = results.to_a.first
-      stub_json_request(:get, %r{/api/v2/exports/tickets}, json(:results => []))
+      stub_json_request(:get, %r{/api/v2/incremental/tickets}, json(:results => []))
 
       results.next
       expect(results.first).to_not eq(first)


### PR DESCRIPTION
The `/exports/tickets` endpoint is no longer supported. Use `/incremental/tickets` instead (see the Zendesk docs on [Incremental Ticket Export](https://developer.zendesk.com/rest_api/docs/support/incremental_export#incremental-ticket-export)).

This is essentially the same change as #287 but also updates the tests. Fixes #243 and #276.