### PR TITLE
Fix missing space inside literal brances

### DIFF
--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -22,7 +22,7 @@ describe ZendeskAPI::Configuration do
   end
 
   it "should merge options with client_options" do
-    subject.client_options = {:ssl => {:verify => false}}
+    subject.client_options = { :ssl => { :verify => false } }
     expect(subject.options[:ssl][:verify]).to eq(false)
   end
 end


### PR DESCRIPTION
# Description

Broke rubocop (again) when I merged https://github.com/zendesk/zendesk_api_client_rb/pull/335 yesterday. Sorry about that!