### PR TITLE
Remove Gemfile.lock

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,5 +49,5 @@ rule(/^version:bump:.*/) do |t|
   new_version = version_parts * '.'
   File.open(file, 'w') { |f| f.write(version_file.sub(old_version, new_version)) }
 
-  sh "bundle && git add #{file} Gemfile.lock && git commit -m 'bump version to #{new_version}'"
+  sh "bundle && git add #{file} && git commit -m 'bump version to #{new_version}'"
 end


### PR DESCRIPTION
## Description

We shouldn't commit `Gemfile.lock` to the library repo (the Gemfile.lock is reserved for apps)