### PR TITLE
Unpin webmock version and reorder Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rake"
 gem "rspec"
 gem "rubocop", "~> 0.64.0"
 gem "vcr"
-gem "webmock", "< 2"
+gem "webmock"
 gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"
 gem "json", "< 2.0", :platforms => :ruby_19

--- a/Gemfile
+++ b/Gemfile
@@ -2,23 +2,27 @@ source 'https://rubygems.org'
 
 gem "jruby-openssl", :platforms => :jruby
 gem "mime-types", "~> 2.99", :platforms => [:ruby_19, :jruby]
-gem "bump"
 gem "rake"
-gem "rspec"
-gem "rubocop", "~> 0.64.0"
-gem "vcr"
-gem "webmock"
 gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"
 gem "json", "< 2.0", :platforms => :ruby_19
 gem "scrub_rb", :platforms => [:ruby_19, :ruby_20, :jruby]
 
+gem "rubocop", "~> 0.64.0", :require => false
+
 group :test do
   gem "simplecov"
   gem "byebug", :platform => [:ruby_20, :ruby_21]
+  gem "webmock"
+  gem "vcr"
+  gem "rspec"
 
   # only used for uploads testing
   gem "actionpack", "~> 3.2"
+end
+
+group :dev do
+  gem "bump"
 end
 
 gemspec


### PR DESCRIPTION
## Description

Webmock "< 2" . [doesn't play very well with](https://github.com/bblimke/webmock/issues/683) > Ruby 2.4 

Also, reordered a bit the Gemfile to exclude testing deps