### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -13,6 +13,14 @@ Gem::Specification.new do |s|
   s.description = 'Ruby wrapper for the REST API at https://www.zendesk.com. Documentation at https://developer.zendesk.com.'
   s.license     = 'Apache License Version 2.0'
 
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/zendesk/zendesk_api_client_rb/issues',
+    'changelog_uri' => "https://github.com/zendesk/zendesk_api_client_rb/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/zendesk_api/#{s.version}",
+    'source_code_uri' => "https://github.com/zendesk/zendesk_api_client_rb/tree/v#{s.version}",
+    'wiki_uri' => 'https://github.com/zendesk/zendesk_api_client_rb/wiki'
+  }
+
   s.files = Dir.glob('{lib,util}/**/*')
 
   s.required_ruby_version     = ">= 2.3"


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/zendesk_api after the next release.