### PR TITLE
Use SVG badges on readme, instead of PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zendesk API Client
 
-[![Build Status](https://secure.travis-ci.org/zendesk/zendesk_api_client_rb.png?branch=master)](http://travis-ci.org/zendesk/zendesk_api_client_rb)
-[![Gem Version](https://badge.fury.io/rb/zendesk_api.png)](http://badge.fury.io/rb/zendesk_api)
-[![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.png)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
+[![Build Status](https://secure.travis-ci.org/zendesk/zendesk_api_client_rb.svg?branch=master)](http://travis-ci.org/zendesk/zendesk_api_client_rb)
+[![Gem Version](https://badge.fury.io/rb/zendesk_api.svg)](http://badge.fury.io/rb/zendesk_api)
+[![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.svg)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
 
 ## Documentation
 


### PR DESCRIPTION
The `.png` badges look pretty terrible on high resolution monitors:

![image](https://user-images.githubusercontent.com/497874/64737472-52742280-d530-11e9-9548-915f1539962a.png)

How about using `.svg` instead:

![image](https://user-images.githubusercontent.com/497874/64737505-6ddf2d80-d530-11e9-9769-5f8b732c82ad.png)
