### PR TITLE
Set a request default timeout for zendesk client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ client = ZendeskAPI::Client.new do |config|
   # config.adapter = :patron
 
   # Merged with the default client options hash
-  # config.client_options = {:ssl => {:verify => false}}
+  # config.client_options = {:ssl => {:verify => false}, :request => {:timeout => 15}}
 
   # When getting the error 'hostname does not match the server certificate'
   # use the API at https://yoursubdomain.zendesk.com/api/v2

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ client = ZendeskAPI::Client.new do |config|
   # config.adapter = :patron
 
   # Merged with the default client options hash
-  # config.client_options = {:ssl => {:verify => false}, :request => {:timeout => 15}}
+  # config.client_options = {:ssl => {:verify => false}, :request => {:timeout => 30}}
 
   # When getting the error 'hostname does not match the server certificate'
   # use the API at https://yoursubdomain.zendesk.com/api/v2

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -59,7 +59,8 @@ module ZendeskAPI
           :user_agent => "ZendeskAPI Ruby #{ZendeskAPI::VERSION}"
         },
         :request => {
-          :open_timeout => 10
+          :open_timeout => 10,
+          :timeout => 30
         },
         :url => @url
       }.merge(client_options)

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -60,7 +60,7 @@ module ZendeskAPI
         },
         :request => {
           :open_timeout => 10,
-          :timeout => 30
+          :timeout => 60
         },
         :url => @url
       }.merge(client_options)

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -80,6 +80,7 @@ describe ZendeskAPI::Client do
           config.url = "https://example.zendesk.com/api/v2"
           config.username = username
           config.token = "token"
+          config.client_options = { :request => {:timeout => 15}}
         end
       end
 
@@ -110,6 +111,10 @@ describe ZendeskAPI::Client do
         it "should add /token to the username" do
           expect(subject.username).to eq("hello/token")
         end
+      end
+
+      it "should have specified timeout when provided" do
+        expect(client.connection.options.timeout).to eq(15)
       end
     end
 

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -80,7 +80,7 @@ describe ZendeskAPI::Client do
           config.url = "https://example.zendesk.com/api/v2"
           config.username = username
           config.token = "token"
-          config.client_options = { :request => {:timeout => 15}}
+          config.client_options = { :request => { :timeout => 15 } }
         end
       end
 

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -80,7 +80,7 @@ describe ZendeskAPI::Client do
           config.url = "https://example.zendesk.com/api/v2"
           config.username = username
           config.token = "token"
-          config.client_options = { :request => { :timeout => 15 } }
+          config.client_options = { :request => { :timeout => 30 } }
         end
       end
 
@@ -114,7 +114,7 @@ describe ZendeskAPI::Client do
       end
 
       it "should have specified timeout when provided" do
-        expect(client.connection.options.timeout).to eq(15)
+        expect(client.connection.options.timeout).to eq(30)
       end
     end
 

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -21,6 +21,10 @@ describe ZendeskAPI::Configuration do
     expect(subject.options[:request][:open_timeout]).to eq(10)
   end
 
+  it "should set a default timeout" do
+    expect(subject.options[:request][:timeout]).to eq(30)
+  end
+
   it "should merge options with client_options" do
     subject.client_options = { :ssl => { :verify => false } }
     expect(subject.options[:ssl][:verify]).to eq(false)

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -22,7 +22,7 @@ describe ZendeskAPI::Configuration do
   end
 
   it "should set a default timeout" do
-    expect(subject.options[:request][:timeout]).to eq(30)
+    expect(subject.options[:request][:timeout]).to eq(60)
   end
 
   it "should merge options with client_options" do


### PR DESCRIPTION
I noticed there's no timeout after a connection has been established. The network can error in this case. I'm not sure if we have some default on the Faraday side or if something is done under the hood for long running requests so I thought I should open this MR as a consideration for this case.