### PR TITLE
Do not run spec lives in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,15 @@ jobs:
     - stage: spec:live
       rvm: 2.6.4
       script: bundle exec rake clean_live set_travis_credentials spec:live
+      if: fork = false # only run spec if we are not in a fork, forks can't read env vars
 
 script:
   - bundle exec rake
   - bundle exec rubocop
 
 branches:
-  only: master
+  only:
+    - master
+    - spec_live
 
 sudo: false


### PR DESCRIPTION
### Description

Travis doesn't allow pull requests builds to access encrypted secrets for security reasons, so we can't really use them on pull requests created by external contributors, so I've configured travis to no run those tests on PRs builds.

The idea then is to merge a PR to an integration branch (`spec_live`) to ensure the live testing is working before merging. That's why I've added that branch to the lists of branches that triggers builds by default