### PR TITLE
Provide a meaningful error when using token auth and username is nil

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -207,7 +207,11 @@ module ZendeskAPI
     end
 
     def set_token_auth
-      if config.token && !config.password
+      return if config.password || config.token.nil?
+
+      if config.username.nil?
+        raise ArgumentError, "you need to provide a username when using API token auth"
+      else
         config.password = config.token
         config.username += "/token" unless config.username.end_with?("/token")
       end

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -113,6 +113,16 @@ describe ZendeskAPI::Client do
         end
       end
 
+      context "when username is nil" do
+        let(:username) { nil }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(
+            ArgumentError, "you need to provide a username when using API token auth"
+          )
+        end
+      end
+
       it "should have specified timeout when provided" do
         expect(client.connection.options.timeout).to eq(30)
       end


### PR DESCRIPTION
Fixes: https://github.com/zendesk/zendesk_api_client_rb/issues/373