### PR TITLE
Use `singular_resource_name` on CreateOrUpdate actions

### DIFF
--- a/lib/zendesk_api/actions.rb
+++ b/lib/zendesk_api/actions.rb
@@ -187,7 +187,7 @@ module ZendeskAPI
     # @param [Hash] attributes The attributes to create.
     def create_or_update!(client, attributes, association = Association.new(:class => self))
       response = client.connection.post("#{association.generate_path}/create_or_update") do |req|
-        req.body = { resource_name => attributes }
+        req.body = { singular_resource_name => attributes }
 
         yield req if block_given?
       end


### PR DESCRIPTION
# Description

The `CreateOrUpdate` is not working properly since it's using the plural name of the resource for the root key, and it should be using the singular name since we are updating an individual resource

Fixes https://github.com/zendesk/zendesk_api_client_rb/issues/308