### PR TITLE
Resolve Faraday deprecation notice

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -194,7 +194,7 @@ module ZendeskAPI
 
     def fetch(*args)
       fetch!(*args)
-    rescue Faraday::Error::ClientError => e
+    rescue Faraday::ClientError => e
       @error = e
 
       []

--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -1,7 +1,7 @@
 # tested via spec/core/middleware/response/raise_error_spec.rb
 module ZendeskAPI
   module Error
-    class ClientError < Faraday::Error::ClientError
+    class ClientError < Faraday::ClientError
       attr_reader :wrapped_exception
 
       def to_s

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -68,7 +68,7 @@ module ZendeskAPI
         end
 
         true
-      rescue Faraday::Error::ClientError => e
+      rescue Faraday::ClientError => e
         if method == :save
           false
         else
@@ -561,7 +561,7 @@ module ZendeskAPI
 
     # Returns the update to a ticket that happens when a macro will be applied.
     # @param [Ticket] ticket Optional {Ticket} to apply this macro to.
-    # @raise [Faraday::Error::ClientError] Raised for any non-200 response.
+    # @raise [Faraday::ClientError] Raised for any non-200 response.
     def apply!(ticket = nil)
       path = "#{self.path}/apply"
 
@@ -577,7 +577,7 @@ module ZendeskAPI
     # @param [Ticket] ticket Optional {Ticket} to apply this macro to
     def apply(ticket = nil)
       apply!(ticket)
-    rescue Faraday::Error::ClientError
+    rescue Faraday::ClientError
       SilentMash.new
     end
   end


### PR DESCRIPTION
The Faraday gem introduced a new [error class structure in v0.9.0](https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/error.rb). Let's reference this new structure instead of the [backward compatibility enabling alias](https://github.com/lostisland/faraday/blob/v0.9.0/lib/faraday/error.rb#L49-L52).

Since Faraday version 0.17.1 a deprecation warning is printed to `STDERR`. This resolves it.

As this new error structure was introduced in Faraday version 0.9.0 and the `zendesk_api` gem requires version 0.9.0 as a minimum, this is a safe change to make.

https://github.com/zendesk/zendesk_api_client_rb/blob/7fe691d0c34f818c13b1b20d1c921b4701e99e73/zendesk_api.gemspec#L29

Fixes #408.