### PR TITLE
Release new version

### DIFF
--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "1.22.0"
+  VERSION = "1.23.0"
 end


### PR DESCRIPTION
I set out to fix the Faraday deprecations errors that were scattered all over our test outputs, errors like `NOTE: Inheriting Faraday::Error::ClientError is deprecated; use Faraday::ClientError instead. It will be removed in or after version 1.0` - only to find that [someone already had fixed this recently](https://github.com/zendesk/zendesk_api_client_rb/pull/409) 🎉 

Tagging and releasing a new version of the gem, to include these changes.

@orien @nogates @romikoops (tagging recent contributors for review, as I am a stranger to this repo)

@zendesk/guide-test-engineering 

