### PR TITLE
Add "update many" to users

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -599,6 +599,7 @@ module ZendeskAPI
 
   class User < Resource
     extend CreateMany
+    extend UpdateMany
     extend CreateOrUpdate
     extend CreateOrUpdateMany
     extend DestroyMany


### PR DESCRIPTION
Hello Team,

First, Thank you for maintaining Zendesk API Ruby client!
Please help me to introduce this fix!

Users have "update many" endpoint.
Ref. https://developer.zendesk.com/rest_api/docs/support/users#update-many-users

But it was removed by this commit; https://github.com/zendesk/zendesk_api_client_rb/commit/f34990dc9f4cbdb66d5cfec7ddf4c7ff05ab77c7

So this is a fix to add the endpoint.

As a background, I maintain the following tool to add some user attribution data to our Zendesk User Fields. Then, the latest version doesn't work because the tool uses update_many!
https://github.com/toru-takahashi/embulk-output-zendesk_users