### PR TITLE
Allow using Faraday 1.x release in gemspec

### DIFF
--- a/lib/zendesk_api/middleware/request/etag_cache.rb
+++ b/lib/zendesk_api/middleware/request/etag_cache.rb
@@ -30,7 +30,11 @@ module ZendeskAPI
 
           @app.call(environment).on_complete do |env|
             if cached && env[:status] == 304 # not modified
+              # Handle differences in serialized env keys in Faraday < 1.0 and 1.0
+              # See https://github.com/lostisland/faraday/pull/847
               env[:body] = cached[:body]
+              env[:response_body] = cached[:response_body]
+
               env[:response_headers].merge!(
                 :etag => cached[:response_headers][:etag],
                 :content_type => cached[:response_headers][:content_type],

--- a/lib/zendesk_api/middleware/response/raise_error.rb
+++ b/lib/zendesk_api/middleware/response/raise_error.rb
@@ -6,7 +6,7 @@ module ZendeskAPI
       class RaiseError < Faraday::Response::RaiseError
         def call(env)
           super
-        rescue Faraday::Error::TimeoutError, Faraday::Error::ConnectionFailed => e
+        rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
           raise Error::NetworkError.new(e, env)
         end
 

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -4,7 +4,7 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
   context "with a failed connection" do
     context "connection failed" do
       before(:each) do
-        stub_request(:any, /.*/).to_raise(Faraday::Error::ConnectionFailed)
+        stub_request(:any, /.*/).to_raise(Faraday::ConnectionFailed)
       end
 
       it "should raise NetworkError" do

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "faraday", ">= 0.9.0", "< 1.0.0"
+  s.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0.0"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 4.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"


### PR DESCRIPTION
[Faraday has released a 1.0 version](https://github.com/lostisland/faraday/blob/master/CHANGELOG.md#v10) last month, but `zendesk_api` depends on the `0.x` series of Faraday versions by gemspec.  

Let's allow using the latest version of Faraday but avoid a major upgrade to `2.x` by maintaining a version constraint.

**Backward compatibility fixes (v. 0.9 - v 1.x compatible):**

* Fix references to the `Faraday::Error` module which was [removed in v `0.9.0` of Faraday](https://github.com/lostisland/faraday/commit/a6c6f1612c225335bf3bf94cf0b88e2e9a315671#diff-1b35e95f85a819bcd3c16d920ecdcffe).
* [Fix serialized environment]](https://github.com/lostisland/faraday/pull/847) for [Etag cache middleware](https://github.com/zendesk/zendesk_api_client_rb/blob/b5c53106bfb1e19715dcc1c167a65b7eb1021c9f/lib/zendesk_api/middleware/request/etag_cache.rb).