### PR TITLE
Allow using hashie 4.x

### DIFF
--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0.0"
-  s.add_runtime_dependency "hashie", ">= 3.5.2", "< 4.0.0"
+  s.add_runtime_dependency "hashie", ">= 3.5.2", "< 5.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
   s.add_runtime_dependency "mime-types"


### PR DESCRIPTION
This change seems safe - there are very few backwards-incompatible changes in Hashie v4. The changelog can be found [here](https://github.com/hashie/hashie/blob/master/CHANGELOG.md).