### PR TITLE
Add support to merge user API

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -682,6 +682,8 @@ module ZendeskAPI
       false
     end
 
+    put :merge
+
     has CustomRole, :inline => true, :include => :roles
     has Role, :inline => true, :include_key => :name
     has Ability, :inline => true


### PR DESCRIPTION
Fix #330

This pull request will add a way to merge a user to another one. It corresponds to "Merge End Users API" https://developer.zendesk.com/rest_api/docs/support/users#merge-end-users




# Usage


```ruby
client = ZendeskAPI::Client.new { |config| ... }
user1 = ZendeskAPI::User.create! client, email: 'aaa@example.com', name: 'aaa'
user2 = ZendeskAPI::User.create! client, email: 'bbb@example.com', name: 'bbb'

# It merges user1 to user2. user1 will be removed and user2 will have the attributes of user1.
user1.merge! user: { id: user2.id }
```


# Note


Note that this change conceals current `ZendeskAPI::User#merge` method.
Currently `ZendeskAPI::User` has `merge` method via `method_missing`.

https://developer.zendesk.com/rest_api/docs/support/users#merge-end-users

This pull request adds an actual `merge` method to the class, so it conceals the delegated `merge` method. 


But I think it will be not a problem in most cases. Merging attributes looks nonsense, and we can also use `user.attributes.merge(something)` instead, if we need to merge the attributes.
Though I think it is a good idea to mention this change as a breaking change in the CHANGELOG because this change will silently break code that uses the current `ZendeskAPI::User#merge`.


