### PR TITLE
Include license in the gem package

### DIFF
--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'wiki_uri' => 'https://github.com/zendesk/zendesk_api_client_rb/wiki'
   }
 
-  s.files = Dir.glob('{lib,util}/**/*')
+  s.files = Dir.glob('{lib,util}/**/*') << 'LICENSE'
 
   s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://developer.zendesk.com"
   s.summary     = 'Zendesk REST API Client'
   s.description = 'Ruby wrapper for the REST API at https://www.zendesk.com. Documentation at https://developer.zendesk.com.'
-  s.license     = 'Apache License Version 2.0'
+  s.license     = 'Apache-2.0'
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/zendesk/zendesk_api_client_rb/issues',


### PR DESCRIPTION
According to terms of the license, to redistribute the package one must also provide a copy of the license.

https://github.com/zendesk/zendesk_api_client_rb/blob/fd431b4b6b5e37906d5e235481e1cfe984830f92/LICENSE#L94-L95

Let's make this easy by including the license in the gem package.