### PR TITLE
Upgrade JSON library and change README badge to use GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Test
 
 on:
   pull_request:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "mime-types", "~> 2.99", :platforms => [:ruby_19, :jruby]
 gem "rake"
 gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"
-gem "json", "< 2.0", :platforms => :ruby_19
+gem "json", ">= 2.3.0", :platforms => :ruby_19
 gem "scrub_rb", :platforms => [:ruby_19, :ruby_20, :jruby]
 
 gem "rubocop", "~> 0.64.0", :require => false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zendesk API Client
 
-[![Build Status](https://secure.travis-ci.org/zendesk/zendesk_api_client_rb.svg?branch=master)](http://travis-ci.org/zendesk/zendesk_api_client_rb)
+![Test](https://github.com/zendesk/zendesk_api_client_rb/workflows/Test/badge.svg)
 [![Gem Version](https://badge.fury.io/rb/zendesk_api.svg)](http://badge.fury.io/rb/zendesk_api)
 [![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.svg)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
 


### PR DESCRIPTION
Use `json` library > 2.3 for ruby 1.9 platforms and update README badge to use the new GitHub actions workflow