### PR TITLE
Add update method example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ ZendeskAPI::Ticket.find!(client, :id => 1)
 ZendeskAPI::Ticket.destroy!(client, :id => 1)
 ```
 
+You can also update ticket objects.
+
+```ruby
+ticket = ZendeskAPI::Ticket.find!(client, :id => 1)
+ticket.update(:comment => { :value => "This is a test reply." })
+
+ticket.save!
+```
+
 Another way is to use the instance methods under client.
 
 ```ruby


### PR DESCRIPTION
Not being able to directly add/modify ticket attributes then saving has caused some frustration. This is also a bit counter-intuitive when combined with Rails syntax where `.update` is a direct method call to save modified values without needing to `.save`. See https://support.zendesk.com/hc/en-us/articles/226316187-Adding-a-comment-to-a-ticket-via-the-API for more examples of confusion.