### PR TITLE
Replace mime-types dependency with mini_mime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "jruby-openssl", :platforms => :jruby
-gem "mime-types", "~> 2.99", :platforms => [:ruby_19, :jruby]
+gem "mini_mime"
 gem "rake"
 gem "addressable", "< 2.5.0", :platforms => [:ruby_19, :jruby]
 gem "yard"

--- a/lib/zendesk_api/middleware/request/upload.rb
+++ b/lib/zendesk_api/middleware/request/upload.rb
@@ -1,5 +1,5 @@
 require "faraday/middleware"
-require "mime/types"
+require "mini_mime"
 require 'tempfile'
 
 module ZendeskAPI
@@ -50,7 +50,10 @@ module ZendeskAPI
               hash = hash[key]
             end
 
-            mime_type ||= MIME::Types.type_for(path).first || "application/octet-stream"
+            unless defined?(mime_type) && !mime_type.nil?
+              mime_type = MiniMime.lookup_by_filename(path)
+              mime_type = mime_type ? mime_type.content_type : "application/octet-stream"
+            end
 
             hash[:filename] ||= if file.respond_to?(:original_filename)
               file.original_filename

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 5.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
-  s.add_runtime_dependency "mime-types"
+  s.add_runtime_dependency "mini_mime"
 end


### PR DESCRIPTION
The mime-types gem is used to determine the MIME type of the uploaded file via the filename.

The [mini_mime](https://github.com/discourse/mini_mime) library is an alternative which has a lower memory footprint. [This pull request on the mail library](https://github.com/mikel/mail/pull/1059) has some discussion on the topic.