### PR TITLE
Disable suspended tickets tests

### DIFF
--- a/spec/live/suspended_ticket_spec.rb
+++ b/spec/live/suspended_ticket_spec.rb
@@ -12,6 +12,8 @@ describe ZendeskAPI::SuspendedTicket do
     }
   end
 
-  it_should_be_readable :suspended_tickets
-  it_should_be_deletable :object => suspended_ticket
+  # TODO: We can't create now suspended tickets automatically via API calls,
+  # which makes this tests very complicated to perform
+  # it_should_be_readable :suspended_tickets
+  # it_should_be_deletable :object => suspended_ticket
 end


### PR DESCRIPTION
We have lost the ability to dynamically create suspended tickets via the API. Thus, we can't create the necessary suspended tickets to test the Index endpoint, and the delete suspended ticket endpoint