### PR TITLE
Update tested Ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.3
-          - 2.4
           - 2.5
           - 2.6
+          - 2.7
+          - 3.0
           - jruby-9.1
           - jruby-9.2
     steps:


### PR DESCRIPTION
### Description

Updated the tested list of Ruby versions used for GitHub Actions.

Added:
- 2.7: Released 2019-12-25
- 3.0: Released 2020-12-25

Removed:
- 2.3: EOL 2019-03-31
- 2.4: EOL 2020-03-31

https://www.ruby-lang.org/en/downloads/branches/
