### PR TITLE
[ZTF-2569] Add more info to ZendeskAPI::Error::RecordInvalid

### DIFF
--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -20,7 +20,7 @@ module ZendeskAPI
         super
 
         if response[:body].is_a?(Hash)
-          @errors = response[:body]["details"] || response[:body]["description"]
+          @errors = response[:body]["details"] || generate_error_msg(response[:body])
         end
 
         @errors ||= {}
@@ -28,6 +28,17 @@ module ZendeskAPI
 
       def to_s
         "#{self.class.name}: #{@errors}"
+      end
+
+      private
+
+      def generate_error_msg(response_body)
+        return unless response_body["description"] || response_body["message"]
+
+        [
+          response_body["description"],
+          response_body["message"]
+        ].compact.join(" - ")
       end
     end
 

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -105,14 +105,14 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
       end
 
       context "with a body" do
-        let(:body) { JSON.dump(:description => "big file is big") }
+        let(:body) { JSON.dump(:description => "big file is big", :message => "small file is small") }
 
         it "should return RecordInvalid with proper message" do
           begin
             client.connection.get "/non_existent"
           rescue ZendeskAPI::Error::RecordInvalid => e
-            expect(e.errors).to eq("big file is big")
-            expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big")
+            expect(e.errors).to eq("big file is big - small file is small")
+            expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big - small file is small")
           else
             fail # didn't raise an error
           end


### PR DESCRIPTION
#### Description
* The error message for `ZendeskAPI::Error::RecordInvalid` does not contain sufficient information at times. Taking the following response body as an example:
```ruby
{
    "error"=>"ZuoraClient::SubscribeCommandFailure",
    "description"=>"An internal error occurred. Please try again", 
    "message"=>"[ TRANSACTION_FAILED: Merchant bank information is incorrect. Check gateway provider settings.999 - Internal Error ]"
}
```
* Original output -> `ZendeskAPI::Error::RecordInvalid: ZendeskAPI::Error::RecordInvalid: An internal error occurred. Please try again`
* New output -> `ZendeskAPI::Error::RecordInvalid: ZendeskAPI::Error::RecordInvalid: An internal error occurred. Please try again - [ TRANSACTION_FAILED: Merchant bank information is incorrect. Check gateway provider settings.999 - Internal Error ]`
* The response body could have other shapes as well. Open to suggestions for more extensible ways to handle this 🙇‍♀️ 