### PR TITLE
CSOPS2-58 added new changes related to the pagination needed on CFZ

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -185,9 +185,8 @@ module ZendeskAPI
       elsif association && association.options.parent && association.options.parent.new_record?
         return (@resources = [])
       end
-
       @response = get_response(@query || path)
-      handle_response(@response.body)
+      handle_response(@response.body, (@query || path))
 
       @resources
     end
@@ -332,6 +331,32 @@ module ZendeskAPI
       end
     end
 
+    def has_more_results?(response)
+      return false unless response["meta"].present? && response["results"].present?
+
+      response["meta"]["has_more"] && response["results"].length > 0
+    end
+
+    def get_response_body(link)
+      response_body = @client.connection.send("get", link).body
+
+      response_body
+    end
+
+    def get_next_page_data(original_response_body)
+      link = original_response_body["links"]["next"]
+
+      while link do
+        response = get_response_body(link)
+
+        original_response_body["results"] = original_response_body["results"] + response["results"]
+
+        link = response['meta']['has_more'] ? response['links']['next'] : nil
+      end
+
+      original_response_body
+    end
+
     def _all(start_page = @options["page"], bang = false, &block)
       raise(ArgumentError, "must pass a block") unless block
 
@@ -410,10 +435,12 @@ module ZendeskAPI
       end
     end
 
-    def handle_response(response_body)
+    def handle_response(response_body, path = nil)
       unless response_body.is_a?(Hash)
         raise ZendeskAPI::Error::NetworkError, @response.env
       end
+
+      response_body = get_next_page_data(response_body) if has_more_results?(response_body)
 
       body = response_body.dup
       results = body.delete(@resource_class.model_key) || body.delete("results")
@@ -426,8 +453,12 @@ module ZendeskAPI
         wrap_resource(res)
       end
 
-      set_page_and_count(body)
-      set_includes(@resources, @includes, body)
+      unless path == 'search/export'
+        set_page_and_count(body)
+        set_includes(@resources, @includes, body)
+
+        return
+      end
     end
 
     # Simplified Associations#wrap_resource

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -312,6 +312,45 @@ module ZendeskAPI
     end
   end
 
+  # This will include the cursor pagination
+  class SearchExport
+    class Result < Data; end
+
+    # Creates a search export collection
+    def self.search_export(client, options = {})
+      unless (%w{query external_id} & options.keys.map(&:to_s)).any?
+        warn "you have not specified a query for this search"
+      end
+
+      ZendeskAPI::Collection.new(client, self, options)
+    end
+
+    # Quack like a Resource
+    # Creates the correct resource class from the result_type passed in
+    def self.new(client, attributes)
+      result_type = attributes["result_type"]
+
+      if result_type
+        result_type = ZendeskAPI::Helpers.modulize_string(result_type)
+        klass = ZendeskAPI.const_get(result_type) rescue nil
+      end
+
+      (klass || Result).new(client, attributes)
+    end
+
+    class << self
+      def resource_name
+        "search/export"
+      end
+
+      alias :resource_path :resource_name
+
+      def model_key
+        "results"
+      end
+    end
+  end
+
   class Request < Resource
     class Comment < DataResource
       include Save

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -863,6 +863,18 @@ describe ZendeskAPI::Collection do
     end
   end
 
+  context "with a module (SearchExport)" do
+    subject { ZendeskAPI::Collection.new(client, ZendeskAPI::SearchExport, :query => "hello") }
+
+    before(:each) do
+      stub_json_request(:get, %r{search/export\?query=hello}, json(:results => []))
+    end
+
+    it "should not blow up" do
+      expect(subject.to_a).to eq([])
+    end
+  end
+
   context "with different path" do
     subject do
       ZendeskAPI::Collection.new(client, ZendeskAPI::TestResource, :collection_path => %w(test_resources active))

--- a/spec/core/search_export_spec.rb
+++ b/spec/core/search_export_spec.rb
@@ -1,0 +1,23 @@
+require 'core/spec_helper'
+
+describe ZendeskAPI::SearchExport do
+  context ".new" do
+    context "when given an existing class" do
+      it "should return the correct class" do
+        expect(ZendeskAPI::SearchExport.new(nil, { "result_type" => "user" })).to be_instance_of(ZendeskAPI::User)
+      end
+    end
+
+    context "when given a nonexistent class" do
+      it "should return an object of the type Search::Result" do
+        expect(ZendeskAPI::SearchExport.new(nil, { "result_type" => "blah" })).to be_instance_of(ZendeskAPI::SearchExport::Result)
+      end
+    end
+
+    context "when not given anything" do
+      it "should return an object of the type Search::Result" do
+        expect(ZendeskAPI::SearchExport.new(nil, {})).to be_instance_of(ZendeskAPI::SearchExport::Result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added new changes related to the new cursor pagination. This was added because we need to update the way how we collect the data. This is mostly because Zendesk is migrating from offset pagination to cursor.