### PR TITLE
Refine `https` check for URL

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -198,7 +198,7 @@ module ZendeskAPI
     end
 
     def check_url
-      if !config.allow_http && config.url !~ /^https/
+      if !config.allow_http && !config.url.start_with?('https://')
         raise ArgumentError, "zendesk_api is ssl only; url must begin with https://"
       end
     end

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -22,6 +22,14 @@ describe ZendeskAPI::Client do
       end.to raise_error(ArgumentError)
     end
 
+    it "should raise an exception when url is multiline and ssl" do
+      expect do
+        ZendeskAPI::Client.new do |config|
+          config.url = "garbage\nhttps://www.google.com"
+        end
+      end.to raise_error(ArgumentError)
+    end
+
     it "should not raise an exception when url isn't ssl and allow_http is set to true" do
       expect do
         ZendeskAPI::Client.new do |config|
@@ -35,6 +43,20 @@ describe ZendeskAPI::Client do
       expect do
         ZendeskAPI::Client.new do |config|
           config.url = "https://example.zendesk.com/api/v2"
+        end.to_not raise_error
+      end
+    end
+
+    it "should handle valid url as a stringlike" do
+      expect do
+        url = Object.new
+
+        def url.to_str
+          "https://example.zendesk.com/api/v2"
+        end
+
+        ZendeskAPI::Client.new do |config|
+          config.url = url
         end.to_not raise_error
       end
     end


### PR DESCRIPTION
1. Disallow multiline url where one of the lines starts with `https`
2. Check for `https://` instead of `https`
3. Allow objects responding to `#to_str` like `Addressable::URI`