### PR TITLE
Support installations with hashie 5.0.0

### DIFF
--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0.0"
-  s.add_runtime_dependency "hashie", ">= 3.5.2", "< 5.0.0"
+  s.add_runtime_dependency "hashie", ">= 3.5.2", "< 6.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"
   s.add_runtime_dependency "mini_mime"


### PR DESCRIPTION
Hashie 5.0.0 is out now, and the restrictions in the gemspec prevent
this gem from working with applications that are using it.

Discourse would like to upgrade to the latest version of this gem
and we cannot support our zendesk plugin without this patch.