### PR TITLE
Fix issue #321: Ticket Comments should be sent unchanged

### DIFF
--- a/lib/zendesk_api/resource.rb
+++ b/lib/zendesk_api/resource.rb
@@ -146,10 +146,16 @@ module ZendeskAPI
 
     alias :to_param :attributes
 
+    def attributes_for_save
+      { self.class.singular_resource_name.to_sym => attribute_changes }
+    end
+
     private
 
-    def attributes_for_save
-      { self.class.singular_resource_name.to_sym => attributes.changes }
+    # Send only the changes, for example, if the "status" attriubte
+    # goes from "new" to "new", we don't need to send anything
+    def attribute_changes
+      attributes.changes
     end
   end
 
@@ -190,7 +196,7 @@ module ZendeskAPI
 
   class SingularResource < Resource
     def attributes_for_save
-      { self.class.resource_name.to_sym => attributes.changes }
+      { self.class.resource_name.to_sym => attribute_changes }
     end
   end
 

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -353,6 +353,13 @@ module ZendeskAPI
     extend UpdateMany
     extend DestroyMany
 
+    # Unlike other attributes, "comment" is not a property of the ticket,
+    # but is used as a "comment on save", so it should be kept unchanged,
+    # See https://github.com/zendesk/zendesk_api_client_rb/issues/321
+    def attribute_changes
+      attributes.changes.merge("comment" => attributes["comment"])
+    end
+
     class Audit < DataResource
       class Event < Data
         has :author, :class => User

--- a/spec/live/ticket_spec.rb
+++ b/spec/live/ticket_spec.rb
@@ -1,6 +1,6 @@
 require 'core/spec_helper'
 
-describe ZendeskAPI::Ticket do
+RSpec.describe ZendeskAPI::Ticket do
   def valid_attributes
     {
       :type => "question",
@@ -26,6 +26,26 @@ describe ZendeskAPI::Ticket do
   it_should_be_readable current_user, :assigned_tickets, create: true
   it_should_be_readable agent, :ccd_tickets, create: true
   it_should_be_readable organization, :tickets
+
+  describe "#attributes_for_save" do
+    let :ticket do
+      described_class.new(instance_double(ZendeskAPI::Client), status: :new)
+    end
+
+    it "keeps all the comments", :vcr do
+      ticket.update(comment: { private: true, body: "Private comment" })
+      expect(ticket.attributes_for_save).to eq(ticket: {
+                                                 "status" => :new,
+                                                 "comment" => { "private" => true, "body" => "Private comment" }
+                                               })
+
+      ticket.update(comment: { private: true, body: "Private comment2" })
+      expect(ticket.attributes_for_save).to eq(ticket: {
+                                                 "status" => :new,
+                                                 "comment" => { "private" => true, "body" => "Private comment2" }
+                                               })
+    end
+  end
 
   context "recent tickets" do
     before(:all) do


### PR DESCRIPTION
https://github.com/zendesk/zendesk_api_client_rb/issues/321

Ticket "Comments" are not regular attributes to be sent only when they change, but they should be sent un-altered all the time.