### PR TITLE
Fix #294 Get article votes

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -420,8 +420,6 @@ module ZendeskAPI
       @collection_path ||= [@resource]
     end
 
-    ## Fetch
-
     def get_response(path)
       @error = nil
       @response = @client.connection.send(@verb || "get", path) do |req|

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -203,7 +203,9 @@ module ZendeskAPI
 
     has Category
 
+    class Vote < Resource; end
     class Article < Resource
+      has_many Vote
     end
 
     has_many Article
@@ -215,6 +217,9 @@ module ZendeskAPI
         "help_center/articles"
       end
     end
+
+    class Vote < Resource; end
+    has_many Vote
   end
 
   class TopicSubscription < Resource

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -1,6 +1,6 @@
 require 'core/spec_helper'
 
-describe ZendeskAPI::Article, :delete_after do
+RSpec.describe ZendeskAPI::Article, :delete_after do
   it "expects article to exist" do
     expect(article).not_to be_nil
   end
@@ -34,6 +34,7 @@ describe ZendeskAPI::Article, :delete_after do
 
         expect(actual.count).to be > 0
         expect(actual.last.title).to eq("What are these sections and articles doing here?")
+        expect(actual.last.votes.any?).to be(true) # Manually set in UI
       end
     end
   end

--- a/spec/live/topic_subscription_spec.rb
+++ b/spec/live/topic_subscription_spec.rb
@@ -8,16 +8,4 @@ describe ZendeskAPI::TopicSubscription, :delete_after, :not_findable do
   end
 
   it_should_be_readable topic, :subscriptions
-
-  # TODO: This resource cannot be found since the response from the server
-  # is using `subscription` as the model name, instead of `topic_subscription`
-  # which is what the save handle_response method is expecting:
-  # https://github.com/zendesk/zendesk_api_client_rb/blob/master/lib/zendesk_api/actions.rb#L5
-  # we should modify it to use the `model_key` if present, but I don't want to do
-  # that now, when I modifying a lot of tests
-  xit "subscription can be found via the topic" do
-    VCR.use_cassette("find_created_topic_subscription") do
-      expect(topic.subscriptions.find(id: subscription.id)).not_to be nil
-    end
-  end
 end


### PR DESCRIPTION
Allows retrieving article votes:

```ruby
article = client.articles.find(id: 123)
article.votes.fetch!
```

See: 

* https://github.com/zendesk/zendesk_api_client_rb/issues/294
* https://developer.zendesk.com/api-reference/help_center/help-center-api/votes/
