### PR TITLE
Add httpx to the gzip exceptions list

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -26,7 +26,7 @@ module ZendeskAPI
   # The top-level class that handles configuration and connection to the Zendesk API.
   # Can also be used as an accessor to resource collections.
   class Client
-    GZIP_EXCEPTIONS = [:em_http, :httpclient]
+    GZIP_EXCEPTIONS = [:em_http, :httpclient, :httpx]
 
     # @return [Configuration] Config instance
     attr_reader :config


### PR DESCRIPTION
httpx supports GZip natively: https://gitlab.com/honeyryderchuck/httpx#httpx-a-ruby-http-library-for-tomorrow-and-beyond