### PR TITLE
Add Translation resource

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -205,8 +205,10 @@ module ZendeskAPI
     has Category
 
     class Vote < Resource; end
+    class Translation < Resource; end
     class Article < Resource
       has_many Vote
+      has_many Translation
     end
 
     has_many Article
@@ -221,6 +223,8 @@ module ZendeskAPI
 
     class Vote < Resource; end
     has_many Vote
+    class Translation < Resource; end
+    has_many Translation
   end
 
   class TopicSubscription < Resource

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe ZendeskAPI::Article, :delete_after do
     expect(article).not_to be_nil
   end
 
+  it "can have translations", :vcr do
+    article.translations.create!(locale: "fr", title: "Traduction", body: "Bonjour")
+
+    expect(article.translations.any?).to be_truthy
+  end
+
   describe "creating articles within a section" do
     def valid_attributes
       { :name => "My Article", user_segment_id: nil, permission_group_id: 2801272, title: "My super article" }


### PR DESCRIPTION
Following the [API documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/translations), this will enable CRUD operations for Article translations.