### PR TITLE
Fix faraday deprecation errors for `authorization`

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -165,7 +165,7 @@ module ZendeskAPI
 
         # request
         if config.access_token && !config.url_based_access_token
-          builder.authorization("Bearer", config.access_token)
+          builder.request(:authorization, "Bearer", config.access_token)
         elsif config.access_token
           builder.use ZendeskAPI::Middleware::Request::UrlBasedAccessToken, config.access_token
         else

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -80,19 +80,22 @@ describe ZendeskAPI::Client do
     end
 
     context "access token" do
-      subject do
-        ZendeskAPI::Client.new do |config|
+      before do
+        @client = ZendeskAPI::Client.new do |config|
           config.url = "https://example.zendesk.com/api/v2"
           config.access_token = "hello"
         end
+
+        stub_request(:get, %r{/bs$}).to_return(:status => 200)
       end
 
       it "should not build basic auth middleware" do
-        expect(subject.connection.builder.handlers.index(Faraday::Request::BasicAuthentication)).to be_nil
+        expect(@client.connection.builder.handlers.index(Faraday::Request::BasicAuthentication)).to be_nil
       end
 
       it "should build token middleware" do
-        expect(subject.connection.headers["Authorization"]).to match(/Bearer/)
+        headers = @client.connection.get('/bs').env.request_headers
+        expect(headers["Authorization"]).to match(/Bearer/)
       end
     end
 


### PR DESCRIPTION
Fixes the deprecation errors:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
```
I couldn't directly use the client in the test since faraday only edits the headers somewhere using the middleware. So I had to make a request and check the request_header there.