### PR TITLE
v1.36.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-# v1.36.0 (WIP)
+# Unreleased
 
+# v1.36.0
+
+- Fix: Ticket comments should be sent unchanged
+- Update README: Document the [REPL project](https://github.com/zendesk/zendesk_api_client_rb_repl), add release instructions
 - Add `Schedule` resource
+- Add `Vote` resource for Articles
+- Add `CustomStatus` resource
+- Add `Translation` resource for Categories, Sections, and Articles
 
 # v1.35.0
 

--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "1.35.0"
+  VERSION = "1.36.0"
 end


### PR DESCRIPTION
[Diff of changes since v1.35.0](https://github.com/zendesk/zendesk_api_client_rb/compare/v1.35.0...4d346d2e6802b51de792ae644e9f4b0fe0b77d88)

TODO:
- [x] Notify internal stakeholders
- [x] Push to Rubygems (post-merge)