### PR TITLE
Improve Error Message for Record Invalid Errors

### DIFF
--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -20,7 +20,7 @@ module ZendeskAPI
         super
 
         if response[:body].is_a?(Hash)
-          @errors = response[:body]["details"] || generate_error_msg(response[:body])
+          @errors = response[:body]["details"] || generate_error_msg(response[:body]) || response[:body]["error"]
         end
 
         @errors ||= {}

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -94,6 +94,21 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
             fail # didn't raise an error
           end
         end
+
+        context "with only an error key" do
+          let(:body) { JSON.dump(:error => "something went wrong") }
+
+          it "should return RecordInvalid with proper message" do
+            begin
+              client.connection.get "/non_existent"
+            rescue ZendeskAPI::Error::RecordInvalid => e
+              expect(e.errors).to eq("something went wrong")
+              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
+            else
+              fail # didn't raise an error
+            end
+          end
+        end
       end
     end
 
@@ -115,6 +130,21 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
             expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big - small file is small")
           else
             fail # didn't raise an error
+          end
+        end
+
+        context "with only an error key" do
+          let(:body) { JSON.dump(:error => "something went wrong") }
+
+          it "should return RecordInvalid with proper message" do
+            begin
+              client.connection.get "/non_existent"
+            rescue ZendeskAPI::Error::RecordInvalid => e
+              expect(e.errors).to eq("something went wrong")
+              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
+            else
+              fail # didn't raise an error
+            end
           end
         end
       end


### PR DESCRIPTION
While attempting to merge 2 users together in Zendesk, I received a 422 response with the response body `{"error"=>"You cannot merge Customer Name while they have an external ID."}`. However, this error message was not included in the raised exception. As a result, our exception monitoring tool only showed `ZendeskAPI::Error::RecordInvalid: {}` without any details. This made determining the actual issue challenging.

I think modifying the code that generates the message for `ZendeskAPI::Error::RecordInvalid` errors to use the message in the `error` key of the response body, if necessary, will improve the usability of this exception.