### PR TITLE
Support Faraday v2

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zendesk/redback

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 2.6
           - 2.7
           - 3.0
           - 3.1
+          - jruby-9.1
+          - jruby-9.2
           - jruby-9.3
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,6 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
-          - jruby-9.1
-          - jruby-9.2
           - jruby-9.3
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.6
           - 2.7
           - 3.0
           - 3.1
-          - jruby-9.1
-          - jruby-9.2
+          - jruby-9.3
     steps:
       - name: Checkout code
         uses: zendesk/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: zendesk/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.6
+          ruby-version: 3.1
       - name: spec:live
         run: |
           bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ coverage/**
 .yardoc/**
 Gemfile.lock
 vendor/bundle/**
-
+pkg/**

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
   DisplayCopNames: true
   Exclude:
     - .git/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
-# Unreleased
+# CHANGELOG
 
-## v2.0.0-beta1
+## Unreleased
 
-- Support for Faraday 2.0
+## v1.38.0
+
+- Add support for Faraday 2.0
+- Drop support for Faraday 1 (BREAKING)
 - Add support for JRuby 9.3
 - Drop support for JRuby 9.1, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110095881
 - Drop support for JRuby 9.2, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110151024
 - NOTE: Support for Ruby 2.6 will drop
 
-## v1.37
+## v1.37.0
 
 - Fix Faraday v1 deprecation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - Support for Faraday 2.0
 - Add support for JRuby 9.3
-- Drop support for JRuby 9.1 and 9.2
-- Drop support for Ruby 2.6
 
 ## v1.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Unreleased
 
-# v1.36.0
+## v2.0.0
+
+- Support for Faraday 2.0
+- Add support for JRuby 9.3
+- Drop support for JRuby 9.1 and 9.2
+- Drop support for Ruby 2.6
+
+## v1.36.0
 
 - Fix: Ticket comments should be sent unchanged
 - Update README: Document the [REPL project](https://github.com/zendesk/zendesk_api_client_rb_repl), add release instructions
@@ -9,7 +16,7 @@
 - Add `CustomStatus` resource
 - Add `Translation` resource for Categories, Sections, and Articles
 
-# v1.35.0
+## v1.35.0
 
 - Abandoned support for Ruby 2.5 (EOL)
 - Tested in Ruby 3.1
@@ -18,115 +25,115 @@
 - Bug-fixing
 - Improved documentation
 
-# v1.34.0
+## v1.34.0
 
 - Refine https check for URL
 - Support installations with hashie 5.0.0
 - Add `OrganizationMembership.create_or_update{,!}`
 
-# v1.33.0
+## v1.33.0
 
 - Expand retry logic to support retries on 5xx error codes
 
-# v1.32.0
+## v1.32.0
 
 - Add more info to ZendeskAPI::Error::RecordInvalid
 
-# v1.31.0
+## v1.31.0
 
 - Upgrade addressable dependency
 
-# v1.30.0
+## v1.30.0
 
 - Add configuration option to disable resource cache
 - Add RecipientAddress resource
 - Upgrade VCR and actionpack testing dependencies
 
-# v1.29.0
+## v1.29.0
 
 - Add Organization Related resource
 - Add Deleted Users and Deleted Tickets resource
 - Switch over mini_mime for mime type lookups
 
-# v1.28.0
+## v1.28.0
 
 - Add Trigger categories resource
 
-# v1.27.0
+## v1.27.0
 
 - Add Section and Article resources
 
-# v1.26.0
+## v1.26.0
 
 - Allow using hashie 4.x
 - Add support to merge user API
 
-# v1.25.0
+## v1.25.0
 
 - Allow using Faraday 1.x release in gemspec
 
-# v1.24.0
+## v1.24.0
 
 - Added support for `UserRelated` operation on users resource
 - Bring back `UpdateMany` on users resource
 
-# v1.23.0
+## v1.23.0
 
 - Fix Faraday deprecation notice and relax required version
 
-# v1.22.0
+## v1.22.0
 
 - Fix `CreateOrUpdate` action to use singular resource name
 - Add `CreateMany`, `CreateOrUpdate` and `DestroyMany` to Organizations
 
-# v1.21.0
+## v1.21.0
 
 - Add support for `.find` attachments
 - Set default request timeout of 60 seconds
 - Add gem project metadata
 - Add meaningful error when the username is not set using basic token auth
 
-# v1.20.0
+## v1.20.0
 
 - Bring back spec live testing
 
-# v1.19.1
+## v1.19.1
 
 - Remove forums resource and start using community topics
 - Add assigned tickets association
 
-# v1.19.0
+## v1.19.0
 
 - Add option to raise error when rate limited
 
-# v1.18.0
+## v1.18.0
 
 - Add support for create_or_update for user resource
 - Update ticket incremental export endpoint
 - Add support to create or update many users and remove unsupported update many users
 - Define respond_to_missing?
 
-# v1.17.0
+## v1.17.0
 
 dropped support for Ruby 1.9.x, 2.0.x, 2.1.x and 2.2.x, all of which are EOL
 
-# v1.16.0
+## v1.16.0
 
 log response body for 4xx errors (https://github.com/zendesk/zendesk_api_client_rb/pull/354)
 
-# v1.15.0
+## v1.15.0
 
 support batch update resources (https://github.com/zendesk/zendesk_api_client_rb/pull/344)
 
-# v1.14.4
+## v1.14.4
 
 document hashie dependency
 
-# v1.14.3
+## v1.14.3
 
 silence logging spam (https://github.com/zendesk/zendesk_api_client_rb/pull/327)
 
-# v1.14.2
+## v1.14.2
 
 make error also work without an response
 
@@ -144,7 +151,7 @@ silence mashie
 You are setting a key that conflicts with a built-in method Hashie::Mash#class defined in Kernel. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
 ```
 
-# v1.14.1
+## v1.14.1
 
 avoid double builds
 
@@ -158,7 +165,7 @@ implements `scrub!` for you.
 
 Fix addressable on older Rubies
 
-# v1.14.0
+## v1.14.0
 
 added live spec
 
@@ -187,20 +194,20 @@ don't install mime-types >= v3.0.
 
 Lock webmock version to get green build
 
-# v1.13.4
+## v1.13.4
 
 fix some rubocop warnings
 
 fix deprecation warning on ruby 2.3.0
 
-# v1.13.3
+## v1.13.3
 
 Add agent Set Group Membership as Default
 
 https://developer.zendesk.com/rest_api/docs/core/group_memberships#set-m
 embership-as-default
 
-# v1.13.2
+## v1.13.2
 
 fix method_as_class to handle non alphanumeric
 
@@ -220,11 +227,11 @@ only show bang! methods in README
 
 DELETEs return 204s now
 
-# v1.13.1
+## v1.13.1
 
 add a gzip middleware exception for httpclient
 
-# v1.12.1
+## v1.12.1
 
 add user \*\_many endpoints
 
@@ -240,33 +247,33 @@ update class documentation link
 
 fix documentation [ci skip]
 
-# v1.12.0
+## v1.12.0
 
 restoring gemspec to the previous required ruby version
 
 Sanitizing body responses to deal with bad characters.
 
-# v1.11.7
+## v1.11.7
 
 Revert "always upload files as inline"
 
 This reverts commit cc97c3733e47f524595b9dc35068218e7a410acd.
 
-# v1.11.6
+## v1.11.6
 
-# v1.11.5
+## v1.11.5
 
 make user tags a proper association
 
-# v1.11.4
+## v1.11.4
 
 add CreateMany and DestroyMany to Ticket
 
-# v1.11.3
+## v1.11.3
 
 small spacing fix
 
-# v1.11.2
+## v1.11.2
 
 always upload files as inline
 
@@ -274,11 +281,11 @@ Update pull request #254
 Add .bundle/ to .gitignore
 Rename Ticket::display to Ticket::display!
 
-# v1.11.1
+## v1.11.1
 
 Get RecordInvalid message from description in absence of details
 
-# v1.11.0
+## v1.11.0
 
 Add agent resource and ticket-display feature
 
@@ -288,7 +295,7 @@ fix documentation for incremental export
 
 issue #250
 
-# v1.10.0
+## v1.10.0
 
 Change User-Agent to be Ruby specific
 
@@ -306,35 +313,35 @@ don't save existing comment associations
 
 silence rspec warnings
 
-# v1.9.6
+## v1.9.6
 
 make Voice::Ticket a CreateResource
 
 Add zendesk voice ticket resource #245
 
-# v1.9.5
+## v1.9.5
 
 destroy_many uses a comma separated list of ids
 
-# v1.9.4
+## v1.9.4
 
 organization memberships are not updatable
 
 Adds Organization Membership resource
 
-# v1.9.3
+## v1.9.3
 
 Actually use the client
 
-# v1.9.2
+## v1.9.2
 
 fix destroy_many! and create_many! on collections
 
-# v1.9.1
+## v1.9.1
 
 Allow bulk actions on collections
 
-# v1.9.0
+## v1.9.0
 
 Introduce reload!
 
@@ -344,7 +351,7 @@ return JobStatus
 
 Bulk actions!
 
-# v1.8.0
+## v1.8.0
 
 update README
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
-## v2.0.0
+## v2.0.0-beta1
 
 - Support for Faraday 2.0
 - Add support for JRuby 9.3
+- Drop support for JRuby 9.1, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110095881
+- Drop support for JRuby 9.2, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110151024
+- NOTE: Support for Ruby 2.6 will drop
 
 ## v1.36.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,6 @@ gem "scrub_rb"
 
 gem "rubocop", "~> 0.64.0", require: false
 
-# TODO: REMOVE, I like debugging like this
-# gem "pry"
-# gem "pry-nav"
-# gem "pry-stack_explorer"
-# gem "pry-doc"
-
 group :test do
   gem "webmock"
   gem "vcr", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ gem "scrub_rb"
 gem "rubocop", "~> 0.64.0", require: false
 
 # TODO: REMOVE, I like debugging like this
-gem "pry"
-gem "pry-nav"
-gem "pry-stack_explorer"
-gem "pry-doc"
+# gem "pry"
+# gem "pry-nav"
+# gem "pry-stack_explorer"
+# gem "pry-doc"
 
 group :test do
   gem "webmock"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,12 @@ gem "scrub_rb"
 
 gem "rubocop", "~> 0.64.0", require: false
 
+# TODO: REMOVE, I like debugging like this
+gem "pry"
+gem "pry-nav"
+gem "pry-stack_explorer"
+gem "pry-doc"
+
 group :test do
   gem "webmock"
   gem "vcr", "~> 6.0"

--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -4,5 +4,8 @@ module ZendeskAPI; end
 require 'pry'
 require 'pry-nav'
 
+require 'faraday'
+require 'faraday/multipart'
+
 require 'zendesk_api/core_ext/inflection'
 require 'zendesk_api/client'

--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -1,11 +1,12 @@
 module ZendeskAPI; end
 
 # TODO: REMOVE, I like debugging like this
-require 'pry'
-require 'pry-nav'
+# require 'pry'
+# require 'pry-nav'
 
 require 'faraday'
 require 'faraday/multipart'
+# require 'faraday/encoding'
 
 require 'zendesk_api/core_ext/inflection'
 require 'zendesk_api/client'

--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -1,4 +1,8 @@
 module ZendeskAPI; end
 
+# TODO: REMOVE, I like debugging like this
+require 'pry'
+require 'pry-nav'
+
 require 'zendesk_api/core_ext/inflection'
 require 'zendesk_api/client'

--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -1,12 +1,7 @@
 module ZendeskAPI; end
 
-# TODO: REMOVE, I like debugging like this
-# require 'pry'
-# require 'pry-nav'
-
 require 'faraday'
 require 'faraday/multipart'
-# require 'faraday/encoding'
 
 require 'zendesk_api/core_ext/inflection'
 require 'zendesk_api/client'

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -110,7 +110,6 @@ module ZendeskAPI
     # @return [Faraday::Connection] Faraday connection for the client
     def connection
       @connection ||= build_connection
-      return @connection
     end
 
     # Pushes a callback onto the stack. Callbacks are executed on responses, last in the Faraday middleware stack.

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -1,5 +1,3 @@
-require 'faraday'
-
 require 'zendesk_api/version'
 require 'zendesk_api/sideloading'
 require 'zendesk_api/configuration'

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -95,12 +95,11 @@ module ZendeskAPI
 
       check_url
 
+      # TODO?
       config.retry = !!config.retry # nil -> false
 
       set_raise_error_when_rated_limited
-
       set_token_auth
-
       set_default_logger
       add_warning_callback
     end
@@ -157,6 +156,7 @@ module ZendeskAPI
         adapter = config.adapter || Faraday.default_adapter
 
         unless GZIP_EXCEPTIONS.include?(adapter)
+          # builder.response :encoding # use Faraday::Encoding middleware
           builder.use ZendeskAPI::Middleware::Response::Gzip
           builder.use ZendeskAPI::Middleware::Response::Deflate
         end

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -165,7 +165,7 @@ module ZendeskAPI
 
         # request
         if config.access_token && !config.url_based_access_token
-          builder.authorization("Bearer", config.access_token)
+          builder.request :authorization, "Bearer", config.access_token
         elsif config.access_token
           # TODO
           builder.use ZendeskAPI::Middleware::Request::UrlBasedAccessToken, config.access_token

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -145,6 +145,8 @@ module ZendeskAPI
     # Retry middleware if retry is true
     def build_connection
       Faraday.new(config.options) do |builder|
+        builder.request :multipart
+
         # response
         builder.use ZendeskAPI::Middleware::Response::RaiseError
         builder.use ZendeskAPI::Middleware::Response::Callback, self

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -167,9 +167,10 @@ module ZendeskAPI
         if config.access_token && !config.url_based_access_token
           builder.authorization("Bearer", config.access_token)
         elsif config.access_token
+          # TODO
           builder.use ZendeskAPI::Middleware::Request::UrlBasedAccessToken, config.access_token
         else
-          builder.use Faraday::Request::BasicAuthentication, config.username, config.password
+          builder.request :authorization, :basic, config.username, config.password
         end
 
         if config.cache

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -95,7 +95,6 @@ module ZendeskAPI
 
       check_url
 
-      # TODO?
       config.retry = !!config.retry # nil -> false
 
       set_raise_error_when_rated_limited
@@ -156,7 +155,6 @@ module ZendeskAPI
         adapter = config.adapter || Faraday.default_adapter
 
         unless GZIP_EXCEPTIONS.include?(adapter)
-          # builder.response :encoding # use Faraday::Encoding middleware
           builder.use ZendeskAPI::Middleware::Response::Gzip
           builder.use ZendeskAPI::Middleware::Response::Deflate
         end

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -152,7 +152,6 @@ module ZendeskAPI
         builder.use ZendeskAPI::Middleware::Response::ParseIsoDates
         builder.use ZendeskAPI::Middleware::Response::ParseJson
         builder.use ZendeskAPI::Middleware::Response::SanitizeResponse
-
         adapter = config.adapter || Faraday.default_adapter
 
         unless GZIP_EXCEPTIONS.include?(adapter)
@@ -184,7 +183,7 @@ module ZendeskAPI
           builder.use ZendeskAPI::Middleware::Request::RaiseRateLimited, :logger => config.logger
         end
 
-        builder.adapter(*adapter)
+        builder.adapter(*adapter, &config.adapter_proc)
       end
     end
 

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -159,15 +159,7 @@ module ZendeskAPI
           builder.use ZendeskAPI::Middleware::Response::Deflate
         end
 
-        # request
-        if config.access_token && !config.url_based_access_token
-          builder.request :authorization, "Bearer", config.access_token
-        elsif config.access_token
-          # TODO
-          builder.use ZendeskAPI::Middleware::Request::UrlBasedAccessToken, config.access_token
-        else
-          builder.request :authorization, :basic, config.username, config.password
-        end
+        set_authentication(builder, config)
 
         if config.cache
           builder.use ZendeskAPI::Middleware::Request::EtagCache, :cache => config.cache
@@ -234,6 +226,17 @@ module ZendeskAPI
         if warning = env[:response_headers]["X-Zendesk-API-Warn"]
           logger.warn "WARNING: #{warning}"
         end
+      end
+    end
+
+    # See https://lostisland.github.io/faraday/middleware/authentication
+    def set_authentication(builder, config)
+      if config.access_token && !config.url_based_access_token
+        builder.request :authorization, "Bearer", config.access_token
+      elsif config.access_token
+        builder.use ZendeskAPI::Middleware::Request::UrlBasedAccessToken, config.access_token
+      else
+        builder.request :authorization, :basic, config.username, config.password
       end
     end
   end

--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -28,6 +28,9 @@ module ZendeskAPI
     # @return [Symbol] Faraday adapter
     attr_accessor :adapter
 
+    # @return [Proc] Faraday adapter proc
+    attr_accessor :adapter_proc
+
     # @return [Boolean] Whether to allow non-HTTPS connections for development purposes.
     attr_accessor :allow_http
 

--- a/lib/zendesk_api/middleware/request/encode_json.rb
+++ b/lib/zendesk_api/middleware/request/encode_json.rb
@@ -6,7 +6,6 @@ module ZendeskAPI
       class EncodeJson < Faraday::Middleware
         CONTENT_TYPE = 'Content-Type'.freeze
         MIME_TYPE = 'application/json'.freeze
-        dependency 'json'
 
         def call(env)
           type = env[:request_headers][CONTENT_TYPE].to_s

--- a/lib/zendesk_api/middleware/response/callback.rb
+++ b/lib/zendesk_api/middleware/response/callback.rb
@@ -4,7 +4,7 @@ module ZendeskAPI
   module Middleware
     module Response
       # @private
-      class Callback < Faraday::Response::Middleware
+      class Callback < Faraday::Middleware # Faraday::Response::Middleware
         def initialize(app, client)
           super(app)
           @client = client

--- a/lib/zendesk_api/middleware/response/callback.rb
+++ b/lib/zendesk_api/middleware/response/callback.rb
@@ -4,7 +4,7 @@ module ZendeskAPI
   module Middleware
     module Response
       # @private
-      class Callback < Faraday::Middleware # Faraday::Response::Middleware
+      class Callback < Faraday::Middleware
         def initialize(app, client)
           super(app)
           @client = client

--- a/lib/zendesk_api/middleware/response/deflate.rb
+++ b/lib/zendesk_api/middleware/response/deflate.rb
@@ -5,7 +5,7 @@ module ZendeskAPI
     module Response
       # Faraday middleware to handle content-encoding = inflate
       # @private
-      class Deflate < Faraday::Response::Middleware
+      class Deflate < Faraday::Middleware # Faraday::Response::Middleware
         def on_complete(env)
           if !env.body.strip.empty? && env[:response_headers]['content-encoding'] == "deflate"
             env.body = Zlib::Inflate.inflate(env.body)

--- a/lib/zendesk_api/middleware/response/deflate.rb
+++ b/lib/zendesk_api/middleware/response/deflate.rb
@@ -5,7 +5,7 @@ module ZendeskAPI
     module Response
       # Faraday middleware to handle content-encoding = inflate
       # @private
-      class Deflate < Faraday::Middleware # Faraday::Response::Middleware
+      class Deflate < Faraday::Middleware
         def on_complete(env)
           if !env.body.strip.empty? && env[:response_headers]['content-encoding'] == "deflate"
             env.body = Zlib::Inflate.inflate(env.body)

--- a/lib/zendesk_api/middleware/response/deflate.rb
+++ b/lib/zendesk_api/middleware/response/deflate.rb
@@ -7,9 +7,10 @@ module ZendeskAPI
       # @private
       class Deflate < Faraday::Middleware
         def on_complete(env)
-          if !env.body.strip.empty? && env[:response_headers]['content-encoding'] == "deflate"
-            env.body = Zlib::Inflate.inflate(env.body)
-          end
+          return if env[:response_headers]['content-encoding'] != "deflate"
+          return if env.body.strip.empty?
+
+          env.body = Zlib::Inflate.inflate(env.body)
         end
       end
     end

--- a/lib/zendesk_api/middleware/response/gzip.rb
+++ b/lib/zendesk_api/middleware/response/gzip.rb
@@ -7,7 +7,7 @@ module ZendeskAPI
     # @private
     module Response
       # Faraday middleware to handle content-encoding = gzip
-      class Gzip < Faraday::Response::Middleware
+      class Gzip < Faraday::Middleware # Faraday::Response::Middleware
         def on_complete(env)
           if !env[:body].strip.empty? && env[:response_headers]['content-encoding'] == "gzip"
             env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read

--- a/lib/zendesk_api/middleware/response/gzip.rb
+++ b/lib/zendesk_api/middleware/response/gzip.rb
@@ -9,9 +9,10 @@ module ZendeskAPI
       # Faraday middleware to handle content-encoding = gzip
       class Gzip < Faraday::Middleware
         def on_complete(env)
-          if !env[:body].strip.empty? && env[:response_headers]['content-encoding'] == "gzip"
-            env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read
-          end
+          return if env[:response_headers]['content-encoding'] != "gzip"
+          return if env[:body].strip.empty?
+
+          env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read
         end
       end
     end

--- a/lib/zendesk_api/middleware/response/gzip.rb
+++ b/lib/zendesk_api/middleware/response/gzip.rb
@@ -10,7 +10,7 @@ module ZendeskAPI
       class Gzip < Faraday::Middleware
         def on_complete(env)
           return if env[:response_headers]['content-encoding'] != "gzip"
-          return if env[:body].strip.empty?
+          return if env[:body].to_s.strip.empty?
 
           env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read
         end

--- a/lib/zendesk_api/middleware/response/gzip.rb
+++ b/lib/zendesk_api/middleware/response/gzip.rb
@@ -7,7 +7,7 @@ module ZendeskAPI
     # @private
     module Response
       # Faraday middleware to handle content-encoding = gzip
-      class Gzip < Faraday::Middleware # Faraday::Response::Middleware
+      class Gzip < Faraday::Middleware
         def on_complete(env)
           if !env[:body].strip.empty? && env[:response_headers]['content-encoding'] == "gzip"
             env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read

--- a/lib/zendesk_api/middleware/response/gzip.rb
+++ b/lib/zendesk_api/middleware/response/gzip.rb
@@ -10,7 +10,7 @@ module ZendeskAPI
       class Gzip < Faraday::Middleware
         def on_complete(env)
           return if env[:response_headers]['content-encoding'] != "gzip"
-          return if env[:body].to_s.strip.empty?
+          return if env[:body].force_encoding(Encoding::BINARY).strip.empty?
 
           env[:body] = Zlib::GzipReader.new(StringIO.new(env[:body])).read
         end

--- a/lib/zendesk_api/middleware/response/parse_iso_dates.rb
+++ b/lib/zendesk_api/middleware/response/parse_iso_dates.rb
@@ -6,7 +6,7 @@ module ZendeskAPI
     module Response
       # Parse ISO dates from response body
       # @private
-      class ParseIsoDates < Faraday::Response::Middleware
+      class ParseIsoDates < Faraday::Middleware # Faraday::Response::Middleware
         def call(env)
           @app.call(env).on_complete do |env|
             parse_dates!(env[:body])

--- a/lib/zendesk_api/middleware/response/parse_iso_dates.rb
+++ b/lib/zendesk_api/middleware/response/parse_iso_dates.rb
@@ -6,7 +6,7 @@ module ZendeskAPI
     module Response
       # Parse ISO dates from response body
       # @private
-      class ParseIsoDates < Faraday::Middleware # Faraday::Response::Middleware
+      class ParseIsoDates < Faraday::Middleware
         def call(env)
           @app.call(env).on_complete do |env|
             parse_dates!(env[:body])

--- a/lib/zendesk_api/middleware/response/parse_json.rb
+++ b/lib/zendesk_api/middleware/response/parse_json.rb
@@ -3,7 +3,7 @@ module ZendeskAPI
   module Middleware
     # @private
     module Response
-      class ParseJson < Faraday::Middleware # Faraday::Response::Middleware
+      class ParseJson < Faraday::Middleware
         CONTENT_TYPE = 'Content-Type'.freeze
 
         def on_complete(env)

--- a/lib/zendesk_api/middleware/response/parse_json.rb
+++ b/lib/zendesk_api/middleware/response/parse_json.rb
@@ -5,7 +5,6 @@ module ZendeskAPI
     module Response
       class ParseJson < Faraday::Response::Middleware
         CONTENT_TYPE = 'Content-Type'.freeze
-        dependency 'json'
 
         def on_complete(env)
           type = env[:response_headers][CONTENT_TYPE].to_s

--- a/lib/zendesk_api/middleware/response/parse_json.rb
+++ b/lib/zendesk_api/middleware/response/parse_json.rb
@@ -3,7 +3,7 @@ module ZendeskAPI
   module Middleware
     # @private
     module Response
-      class ParseJson < Faraday::Response::Middleware
+      class ParseJson < Faraday::Middleware # Faraday::Response::Middleware
         CONTENT_TYPE = 'Content-Type'.freeze
 
         def on_complete(env)

--- a/lib/zendesk_api/middleware/response/sanitize_response.rb
+++ b/lib/zendesk_api/middleware/response/sanitize_response.rb
@@ -1,7 +1,7 @@
 module ZendeskAPI
   module Middleware
     module Response
-      class SanitizeResponse < Faraday::Response::Middleware
+      class SanitizeResponse < Faraday::Middleware # Faraday::Response::Middleware
         def on_complete(env)
           env[:body].scrub!('')
         end

--- a/lib/zendesk_api/middleware/response/sanitize_response.rb
+++ b/lib/zendesk_api/middleware/response/sanitize_response.rb
@@ -1,7 +1,7 @@
 module ZendeskAPI
   module Middleware
     module Response
-      class SanitizeResponse < Faraday::Middleware # Faraday::Response::Middleware
+      class SanitizeResponse < Faraday::Middleware
         def on_complete(env)
           env[:body].scrub!('')
         end

--- a/lib/zendesk_api/verbs.rb
+++ b/lib/zendesk_api/verbs.rb
@@ -44,14 +44,12 @@ module ZendeskAPI
           end
 
           define_method method do |*method_args|
-            begin
-              send("#{method}!", *method_args)
-            rescue ZendeskAPI::Error::RecordInvalid => e
-              @errors = e.errors
-              false
-            rescue ZendeskAPI::Error::ClientError
-              false
-            end
+            send("#{method}!", *method_args)
+          rescue ZendeskAPI::Error::RecordInvalid => e
+            @errors = e.errors
+            false
+          rescue ZendeskAPI::Error::ClientError
+            false
           end
         end
       end

--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "1.37.0"
+  VERSION = "1.38.0.rc1"
 end

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -70,8 +70,8 @@ describe ZendeskAPI::Client do
         end
       end
 
-      it "should build basic auth middleware" do
-        expect(subject.connection.builder.handlers.index(Faraday::Request::BasicAuthentication)).to_not be_nil
+      it "should include Request::Authorization in the handlers" do
+        expect(subject.connection.builder.handlers).to include(Faraday::Request::Authorization)
       end
 
       it "should not build token middleware" do

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -6,7 +6,9 @@ class SimpleClient < ZendeskAPI::Client
   end
 end
 
-describe ZendeskAPI::Client do
+RSpec.describe ZendeskAPI::Client do
+  subject { client }
+
   describe "#tickets" do
     subject do
       ZendeskAPI::Client.new do |config|
@@ -30,8 +32,6 @@ describe ZendeskAPI::Client do
       end
     end
   end
-
-  subject { client }
 
   context "#initialize" do
     it "should require a block" do

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -14,8 +14,8 @@ describe ZendeskAPI::Client do
         config.access_token = access_token
         config.adapter = :test
         config.adapter_proc = proc do |stub|
-          stub.get "/api/v2/tickets" do |env|
-            [200, {"Content-Type": "application/json"}, "null"]
+          stub.get "/api/v2/tickets" do |_env|
+            [200, { "Content-Type": "application/json" }, "null"]
           end
         end
       end

--- a/spec/core/client_spec.rb
+++ b/spec/core/client_spec.rb
@@ -71,7 +71,8 @@ describe ZendeskAPI::Client do
       end
 
       it "should include Request::Authorization in the handlers" do
-        expect(subject.connection.builder.handlers).to include(Faraday::Request::Authorization)
+        expect(subject.connection.builder.handlers)
+          .to include(Faraday::Request::Authorization)
       end
 
       it "should not build token middleware" do
@@ -87,8 +88,9 @@ describe ZendeskAPI::Client do
         end
       end
 
-      it "should not build basic auth middleware" do
-        expect(subject.connection.builder.handlers.index(Faraday::Request::BasicAuthentication)).to be_nil
+      it "should include Request::Authorization in the handlers" do
+        expect(subject.connection.builder.handlers)
+          .to include(Faraday::Request::Authorization)
       end
 
       it "should build token middleware" do
@@ -118,8 +120,9 @@ describe ZendeskAPI::Client do
       end
 
       context "with no password" do
-        it "should build basic auth middleware" do
-          expect(client.connection.builder.handlers.index(Faraday::Request::BasicAuthentication)).to_not be_nil
+        it "should include Request::Authorization in the handlers" do
+          expect(client.connection.builder.handlers)
+            .to include(Faraday::Request::Authorization)
         end
 
         it "should not build token middleware" do

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -262,12 +262,10 @@ describe ZendeskAPI::Collection do
 
       it "should retry from the same page!" do
         expect do |b|
-          begin
-            subject.all!(&b)
-          rescue ZendeskAPI::Error::NetworkError
-            retry
-          rescue ZendeskAPI::Error::ClientError
-          end
+          subject.all!(&b)
+        rescue ZendeskAPI::Error::NetworkError
+          retry
+        rescue ZendeskAPI::Error::ClientError
         end.to yield_successive_args(
           [ZendeskAPI::TestResource.new(client, :id => 1), 1],
           [ZendeskAPI::TestResource.new(client, :id => 2), 2]

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -85,14 +85,12 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
         let(:body) { JSON.dump(:details => "hello") }
 
         it "should return RecordInvalid with proper message" do
-          begin
-            client.connection.get "/non_existent"
-          rescue ZendeskAPI::Error::RecordInvalid => e
-            expect(e.errors).to eq("hello")
-            expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: hello")
-          else
-            fail # didn't raise an error
-          end
+          client.connection.get "/non_existent"
+        rescue ZendeskAPI::Error::RecordInvalid => e
+          expect(e.errors).to eq("hello")
+          expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: hello")
+        else
+          fail # didn't raise an error
         end
       end
     end
@@ -108,14 +106,12 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
         let(:body) { JSON.dump(:description => "big file is big", :message => "small file is small") }
 
         it "should return RecordInvalid with proper message" do
-          begin
-            client.connection.get "/non_existent"
-          rescue ZendeskAPI::Error::RecordInvalid => e
-            expect(e.errors).to eq("big file is big - small file is small")
-            expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big - small file is small")
-          else
-            fail # didn't raise an error
-          end
+          client.connection.get "/non_existent"
+        rescue ZendeskAPI::Error::RecordInvalid => e
+          expect(e.errors).to eq("big file is big - small file is small")
+          expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big - small file is small")
+        else
+          fail # didn't raise an error
         end
       end
     end

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -1,7 +1,5 @@
 $:.unshift(File.join(File.dirname(__FILE__), "macros"))
 
-# TODO: coverage
-
 ENV['TZ'] = 'CET' # something that is not local and not utc so we find all the bugs
 
 require 'zendesk_api'

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -136,12 +136,10 @@ RSpec.configure do |c|
   end
 
   c.around(:each, :prevent_logger_changes) do |example|
-    begin
-      old_logger = client.config.logger
-      example.call
-    ensure
-      client.config.logger = old_logger
-    end
+    old_logger = client.config.logger
+    example.call
+  ensure
+    client.config.logger = old_logger
   end
 
   c.extend ResourceMacros

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -1,5 +1,7 @@
 $:.unshift(File.join(File.dirname(__FILE__), "macros"))
 
+# TODO: coverage
+
 ENV['TZ'] = 'CET' # something that is not local and not utc so we find all the bugs
 
 require 'zendesk_api'

--- a/spec/fixtures/zendesk.rb
+++ b/spec/fixtures/zendesk.rb
@@ -90,9 +90,9 @@ module ZendeskAPI
 
     def organization
       VCR.use_cassette('valid_organization') do
-        # current_user.organization
-        # ... or, maybe:
-        @organization ||= current_user.organization || client.organizations.fetch!.last
+        current_user.organization
+        # ... or, if you can't work it out locally:
+        # @organization ||= current_user.organization || client.organizations.fetch!.last
       end
     end
 

--- a/spec/fixtures/zendesk.rb
+++ b/spec/fixtures/zendesk.rb
@@ -90,7 +90,9 @@ module ZendeskAPI
 
     def organization
       VCR.use_cassette('valid_organization') do
-        @organization ||= current_user.organization
+        # current_user.organization
+        # ... or, maybe:
+        @organization ||= current_user.organization || client.organizations.fetch!.last
       end
     end
 

--- a/spec/live/organization_spec.rb
+++ b/spec/live/organization_spec.rb
@@ -64,6 +64,7 @@ describe ZendeskAPI::Organization, :delete_after do
       end
     end
 
+    # If fails, try deleting the orgs using the REPL
     it "creates many and then it can destroy many" do
       created_orgs = create_many_job.results.filter { |x| x["status"] == "Created" }
 

--- a/spec/live/tag_spec.rb
+++ b/spec/live/tag_spec.rb
@@ -1,9 +1,11 @@
 require 'core/spec_helper'
 
-describe ZendeskAPI::Tag, :vcr, :not_findable do
+RSpec.describe ZendeskAPI::Tag, :vcr, :not_findable do
   [organization, user, ticket].each do |object|
+    raise "Your setup is invalid, see spec/live/Readme.md" unless object
+
     under object do
-      before(:each) do
+      before do
         parent.tags = %w{tag2 tag3}
         parent.tags.save!
       end

--- a/spec/live/user_spec.rb
+++ b/spec/live/user_spec.rb
@@ -133,6 +133,7 @@ describe ZendeskAPI::User, :delete_after do
         end
       end
 
+      # If fails, try deleting the orgs using the REPL
       it "updates all the users, and then, it deletes them properly" do
         created_user_objects.each do |user|
           expect(user.notes).to eq "this is a note"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "faraday", "> 2.0.0"
   s.add_runtime_dependency "faraday-multipart"
-  # s.add_runtime_dependency "faraday-encoding"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 6.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,util}/**/*') << 'LICENSE'
 
-  s.required_ruby_version     = ">= 2.3" # TODO
+  s.required_ruby_version     = ">= 2.6"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "> 2.0.0"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "faraday", ">= 0.9.0", "< 2.0.0"
+  s.add_runtime_dependency "faraday", "> 2.0.0"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 6.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "> 2.0.0"
+  s.add_runtime_dependency "faraday-multipart"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 6.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"

--- a/zendesk_api.gemspec
+++ b/zendesk_api.gemspec
@@ -23,11 +23,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,util}/**/*') << 'LICENSE'
 
-  s.required_ruby_version     = ">= 2.3"
+  s.required_ruby_version     = ">= 2.3" # TODO
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_runtime_dependency "faraday", "> 2.0.0"
   s.add_runtime_dependency "faraday-multipart"
+  # s.add_runtime_dependency "faraday-encoding"
   s.add_runtime_dependency "hashie", ">= 3.5.2", "< 6.0.0"
   s.add_runtime_dependency "inflection"
   s.add_runtime_dependency "multipart-post", "~> 2.0"


### PR DESCRIPTION
A very popular request for our Gem. Support for Faraday 2, which has been released early in the year. We are preventing our users from updating, but, no more! This BETA release allows users to update Faraday.

We expect to leave this feature in BETA for 6 months during which we can address any problem our customers have with the update. The release will follow after the PR is merged.

Please let us know your thoughts and any problems you encounter.

Fixes #488.

---

**Note**: At the moment JRuby 9.1 and 9.2 are not supported in this version. Further investigation _might_ find a fix, but it's likely we will stop testing against JRuby 9.1 and JRuby 9.2.

See [Faraday Documentation](https://www.rubydoc.info/gems/faraday_middleware/1.2.0#as-of-v0-16-0-faraday-and-faraday_middleware-no-longer-officially-support-jruby-or-rubinius):

> As of v0.16.0, faraday and faraday_middleware no longer officially support JRuby or Rubinius.

Our tests kept working until this upgrade, but unfortunately, both [JRuby 9.1](https://github.com/zendesk/zendesk_api_client_rb/runs/8110095881) and [JRuby 9.2](https://github.com/zendesk/zendesk_api_client_rb/runs/8110151024) stopped working.

However, it is unclear if the latest v1 actually does support [JRuby 9.1](https://github.com/zendesk/zendesk_api_client_rb/runs/8127916517?check_suite_focus=true#step:4:117) or [JRuby 9.2](https://github.com/zendesk/zendesk_api_client_rb/runs/8127998606?check_suite_focus=true#step:4:117).