### PR TITLE
Add `Article::Label` resource

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -228,6 +228,12 @@ module ZendeskAPI
     has_many Vote
     class Translation < Resource; end
     has_many Translation
+    class Label < DataResource
+      include Read
+      include Create
+      include Destroy
+    end
+    has_many Label
   end
 
   class TopicSubscription < Resource

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe ZendeskAPI::Article, :delete_after do
     expect(article.translations.map(&:locale)).to include("fr")
   end
 
+  it "can have labels", :vcr do
+    article.labels.create(name: "test-label")
+
+    expect(article.labels.map(&:name)).to include("test-label")
+  end
+
   describe "creating articles within a section" do
     def valid_attributes
       { :name => "My Article", user_segment_id: nil, permission_group_id: 2801272, title: "My super article" }

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe ZendeskAPI::Article, :delete_after do
   end
 
   it "can have labels", :vcr do
-    article.labels.create(name: "test-label")
+    label = article.labels.create!(name: "ruby-client-test-label")
 
-    expect(article.labels.map(&:name)).to include("test-label")
+    expect(article.labels.map(&:name)).to include(label.name)
+
+    label.destroy
   end
 
   describe "creating articles within a section" do

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ZendeskAPI::Article, :delete_after do
     label = article.labels.create!(name: "ruby-client-test-label")
 
     expect(article.labels.map(&:name)).to include(label.name)
-
-    label.destroy
+  ensure # Cleanup
+    label&.destroy
   end
 
   describe "creating articles within a section" do


### PR DESCRIPTION
cc: @zendesk/i18n 

Per the [API docs](https://developer.zendesk.com/api-reference/help_center/help-center-api/article_labels/), we are able to list / add / remove labels from articles. This adds support for those endpoints to this client.

📝 This can currently be done using `article#update(label_names:)`, which will _overwrite_ the labels on a given article with whatever labels are passed to the update.