### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,9 @@ jobs:
         ruby:
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
           - 3.1
+          - 3.2
           - jruby-9.3
     steps:
       - name: Checkout code


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix. 