### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,9 @@ jobs:
         ruby:
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
           - 3.1
+          - 3.2
           - jruby-9.3
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.6
-          - 2.7
+          - "2.6"
+          - "2.7"
           - "3.0"
-          - 3.1
-          - 3.2
-          - jruby-9.3
+          - "3.1"
+          - "3.2"
+          - "jruby-9.3"
     steps:
       - name: Checkout code
         uses: zendesk/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## Unreleased
 
-## v1.38.0
+## v1.38.0 (rc2)
 
 - Add `Label` resource for Articles
 - Add support for Faraday 2.0
 - Drop support for Faraday 1 (BREAKING)
-- Add support for JRuby 9.3
+- Add JRuby 9.3 to CI
+- Add Ruby 3.2 to CI
 - Drop support for JRuby 9.1, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110095881
 - Drop support for JRuby 9.2, see https://github.com/zendesk/zendesk_api_client_rb/runs/8110151024
-- NOTE: Support for Ruby 2.6 will drop
+- Drop support for 2.6, not supported by Faraday 2.0
 
 ## v1.37.0
 


### PR DESCRIPTION
Add support for Ruby 3.2 in CI.

Thank you to @petergoldstein , see https://github.com/zendesk/zendesk_api_client_rb/pull/517

Note that there is more work I need to do on the CHANGELOG, but I'm keeping this step separate.