### PR TITLE
[RED-1548] Fix issue with Faraday::Multipart

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -143,8 +143,6 @@ module ZendeskAPI
     # Retry middleware if retry is true
     def build_connection
       Faraday.new(config.options) do |builder|
-        builder.request :multipart
-
         # response
         builder.use ZendeskAPI::Middleware::Response::RaiseError
         builder.use ZendeskAPI::Middleware::Response::Callback, self


### PR DESCRIPTION
cc @zendesk/redback 

### Description

This PR only removes the Faraday multipart middleware that was already being introduced further down the line in `client.rb`. It also adds a test in regards to the fix. 

## Links
[Issue](https://github.com/zendesk/zendesk_api_client_rb/issues/513)

Replicated issue:
![replicated](https://user-images.githubusercontent.com/309246/222632934-5596529b-76a3-46b8-8283-8d5ff255478e.jpg)

Same test after the fix:
![fixed](https://user-images.githubusercontent.com/309246/222633018-bf696111-d5bb-47f1-9fb8-29e298948d23.jpg)

