### PR TITLE
Fix deleting labels from an article

### DIFF
--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -232,6 +232,12 @@ module ZendeskAPI
       include Read
       include Create
       include Destroy
+
+      def destroy!
+        super do |req|
+          req.path = path
+        end
+      end
     end
     has_many Label
   end


### PR DESCRIPTION
Following https://github.com/zendesk/zendesk_api_client_rb/commit/a81e57507a21a33c5b422475faf61a5a373e4ae1, reading and creating labels for articles work as expected - but deleting a label ends up removing the label from the instance _entirely_ (which removes it from all articles) _when being done via through the `article.labels` association_

This is due to the `destroy!` action preferring the `url` v. `path`
https://github.com/zendesk/zendesk_api_client_rb/blob/ce17a2d7f932bcc2b779b4a10935745b9d6b8aa6/lib/zendesk_api/actions.rb#L234
which, in the case of article labels, `url` returns the [delete label](https://developer.zendesk.com/api-reference/help_center/help-center-api/article_labels/#delete-label) endpoint, while `path` returns the [delete label from article endpoint](https://developer.zendesk.com/api-reference/help_center/help-center-api/article_labels/#delete-label-from-article).

📝 It wasn't clear how `url` is constructed (and/or if there is a way of forcing the appropriate path by an option somewhere within the `has_many` association on article), but overriding the `delete!` function to force the correct path here addressed the original issue.