### PR TITLE
Improve `RecordInvalid` error handling

### DIFF
--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -20,7 +20,7 @@ module ZendeskAPI
         super
 
         if response[:body].is_a?(Hash)
-          @errors = response[:body]["details"] || generate_error_msg(response[:body])
+          @errors = response[:body]["details"] || generate_error_msg(response[:body]) || response[:body]["error"]
         end
 
         @errors ||= {}

--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -20,7 +20,7 @@ module ZendeskAPI
         super
 
         if response[:body].is_a?(Hash)
-          @errors = response[:body]["details"] || generate_error_msg(response[:body]) || response[:body]["error"]
+          @errors = response[:body]["details"] || generate_error_msg(response[:body])
         end
 
         @errors ||= {}
@@ -33,11 +33,11 @@ module ZendeskAPI
       private
 
       def generate_error_msg(response_body)
-        return unless response_body["description"] || response_body["message"]
-
         [
           response_body["description"],
-          response_body["message"]
+          response_body["message"],
+          response_body["error"],
+          response_body["errors"]
         ].compact.join(" - ")
       end
     end

--- a/lib/zendesk_api/error.rb
+++ b/lib/zendesk_api/error.rb
@@ -33,12 +33,7 @@ module ZendeskAPI
       private
 
       def generate_error_msg(response_body)
-        [
-          response_body["description"],
-          response_body["message"],
-          response_body["error"],
-          response_body["errors"]
-        ].compact.join(" - ")
+        response_body.values_at("description", "message", "error", "errors").compact.join(" - ")
       end
     end
 

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -93,17 +93,18 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
           fail # didn't raise an error
         end
 
-        context "with only an error key" do
-          let(:body) { JSON.dump(:error => "something went wrong") }
+        {
+          error: 'There was an error',
+          errors: 'There were several errors'
+        }.each do |key, message|
+          context "with only an #{key} key" do
+            let(:body) { JSON.dump(key => message) }
 
-          it "should return RecordInvalid with proper message" do
-            begin
-              client.connection.get "/non_existent"
-            rescue ZendeskAPI::Error::RecordInvalid => e
-              expect(e.errors).to eq("something went wrong")
-              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
-            else
-              fail # didn't raise an error
+            it "should return RecordInvalid with proper message" do
+              expect { client.connection.get "/non_existent" }.to raise_error do |error|
+                expect(error).to be_a(ZendeskAPI::Error::RecordInvalid)
+                expect(error.errors).to eq(message)
+              end
             end
           end
         end
@@ -129,17 +130,18 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
           fail # didn't raise an error
         end
 
-        context "with only an error key" do
-          let(:body) { JSON.dump(:error => "something went wrong") }
+        {
+          error: 'There was an error',
+          errors: 'There were several errors'
+        }.each do |key, message|
+          context "with only an #{key} key" do
+            let(:body) { JSON.dump(key => message) }
 
-          it "should return RecordInvalid with proper message" do
-            begin
-              client.connection.get "/non_existent"
-            rescue ZendeskAPI::Error::RecordInvalid => e
-              expect(e.errors).to eq("something went wrong")
-              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
-            else
-              fail # didn't raise an error
+            it "should return RecordInvalid with proper message" do
+              expect { client.connection.get "/non_existent" }.to raise_error do |error|
+                expect(error).to be_a(ZendeskAPI::Error::RecordInvalid)
+                expect(error.errors).to eq(message)
+              end
             end
           end
         end

--- a/spec/core/middleware/response/raise_error_spec.rb
+++ b/spec/core/middleware/response/raise_error_spec.rb
@@ -92,6 +92,21 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
         else
           fail # didn't raise an error
         end
+
+        context "with only an error key" do
+          let(:body) { JSON.dump(:error => "something went wrong") }
+
+          it "should return RecordInvalid with proper message" do
+            begin
+              client.connection.get "/non_existent"
+            rescue ZendeskAPI::Error::RecordInvalid => e
+              expect(e.errors).to eq("something went wrong")
+              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
+            else
+              fail # didn't raise an error
+            end
+          end
+        end
       end
     end
 
@@ -112,6 +127,21 @@ describe ZendeskAPI::Middleware::Response::RaiseError do
           expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: big file is big - small file is small")
         else
           fail # didn't raise an error
+        end
+
+        context "with only an error key" do
+          let(:body) { JSON.dump(:error => "something went wrong") }
+
+          it "should return RecordInvalid with proper message" do
+            begin
+              client.connection.get "/non_existent"
+            rescue ZendeskAPI::Error::RecordInvalid => e
+              expect(e.errors).to eq("something went wrong")
+              expect(e.to_s).to eq("ZendeskAPI::Error::RecordInvalid: something went wrong")
+            else
+              fail # didn't raise an error
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Building off of https://github.com/zendesk/zendesk_api_client_rb/pull/503, this adds an additional key (`errors`) to improve the error message output under certain conditions (seen when creating translations on an instance where the locale is not supported).