### PR TITLE
Auto publish gem to RubyGems

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Upcoming changes
 
+## v2.0.1
+
+- More complete error message for `RecordInvalid`
+
 ## v2.0.0 (BREAKING!)
 
 - Add support for Faraday 2.0

--- a/README.md
+++ b/README.md
@@ -431,11 +431,12 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
 
 ## Releasing a new gem version
 
-1. Execute `bundle exec rake bump:patch --tag`, or minor or major according to [SemVer](https://semver.org), this bumps the version in your local machine in the latest commit
-2. Update the CHANGELOG amending the previous commit, so the bump and the CHANGELOG changes are in the same commit
+1. Ensure the CHANGELOG is correct and updated, this is your last opportunity
+2. Execute `bundle exec bump patch --tag`, or minor or major according to [SemVer](https://semver.org), this bumps the version in your local machine in the latest commit
 3. Push to GitHub `git push && git push origin vX.X.X`
-4. Post a message in Slack `#rest-api`, so advocacy are aware that we are going to release a new gem, just in case any customer complains about something related to the gem
-5. Raise a PR, get it approved and merge
+4. Raise a PR and get it approved
+5. Post a message in Slack `#rest-api`, so advocacy are aware that we are going to release a new gem, just in case any customer complains about something related to the gem
+6. After 2 hours from the above message, merge the PR
 
 ## Contributing
 
@@ -448,7 +449,7 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
    we can ignore when we pull.)
 5. Submit a pull request.
 
-**Note:** Live specs will likely fail for external contributors. The Zendesk devs can help with that. If you have permissions and the live specs unexpectedly fail, that might be a data error, see the REPL for that.
+**Note:** Live specs will likely fail for external contributors. The Zendesk devs can help with that. If you have permissions and some live specs unexpectedly fail, that might be a data error, see the REPL for that.
 
 ## Copyright and license
 

--- a/README.md
+++ b/README.md
@@ -434,9 +434,9 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
 1. Ensure the CHANGELOG is correct and updated, this is your last opportunity
 2. Execute `bundle exec bump patch --tag`, or minor or major according to [SemVer](https://semver.org), this bumps the version in your local machine in the latest commit
 3. Push to GitHub `git push && git push origin vX.X.X`
-4. Raise a PR and get it approved
+4. Raise a PR and get it approved and merged
 5. Post a message in Slack `#rest-api`, so advocacy are aware that we are going to release a new gem, just in case any customer complains about something related to the gem
-6. After 2 hours from the above message, merge the PR
+6. After 2 hours from the above message, you can [approve the release of the gem](https://github.com/zendesk/zendesk_api_client_rb/deployments/activity_log?environment=rubygems-publish)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -431,11 +431,11 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
 
 ## Releasing a new gem version
 
-1. Execute `bundle exec rake bump:minor`, which bumps the version in my local machine in a specific commit
-2. Change the CHANGELOG and amend that previous commit, so the bump commit and the CHANGELOG changes are in the same commit (example)
-3. Push to Github
+1. Execute `bundle exec rake bump:patch --tag`, or minor or major according to [SemVer](https://semver.org), this bumps the version in your local machine in the latest commit
+2. Update the CHANGELOG amending the previous commit, so the bump and the CHANGELOG changes are in the same commit
+3. Push to GitHub `git push && git push origin vX.X.X`
 4. Post a message in Slack `#rest-api`, so advocacy are aware that we are going to release a new gem, just in case any customer complains about something related to the gem
-5. After a couple of hours, run `bundle exec rake release`, which automatically pushes the tag to GitHub and releases a new version to Rubygems (it does the gem push for you)
+5. Raise a PR, get it approved and merge
 
 ## Contributing
 
@@ -448,8 +448,10 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
    we can ignore when we pull.)
 5. Submit a pull request.
 
+**Note:** Live specs will likely fail for external contributors. The Zendesk devs can help with that. If you have permissions and the live specs unexpectedly fail, that might be a data error, see the REPL for that.
+
 ## Copyright and license
 
-Copyright 2015-2022 Zendesk
+Copyright 2015-2023 Zendesk
 
 See [LICENSE](./LICENSE).

--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
After this change we won't need to do manual releases, just bump the version, which still requires a PR, but the README should make it effortless.

We already have a small change to deliver, already in master, let's try to test and release this too.