### PR TITLE
Re-run failed live specs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,6 @@ jobs:
       - name: spec:live
         run: |
           bundle install
-          bundle exec rake clean_live set_ci_credentials spec:live
-          bundle exec rake clean_live
+          bundle exec rake clean_live set_ci_credentials spec:live ||
+          bundle exec rake clean_live &&
           bundle exec rspec spec/live --only-failures

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,5 @@ jobs:
         run: |
           bundle install
           bundle exec rake clean_live set_ci_credentials spec:live
+          bundle exec rake clean_live
           bundle exec rspec spec/live --only-failures

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,4 @@ jobs:
         run: |
           bundle install
           bundle exec rake clean_live set_ci_credentials spec:live
+          bundle exec rspec spec/live --only-failures

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 doc/**
+spec/examples.txt
 spec/fixtures/cassettes
 spec/fixtures/credentials.yml
 coverage/**

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -142,6 +142,9 @@ RSpec.configure do |c|
     client.config.logger = old_logger
   end
 
+  # Used by `rspec spec/live --only-failures` in CI
+  c.example_status_persistence_file_path = "spec/examples.txt"
+
   c.extend ResourceMacros
   c.extend ZendeskAPI::Fixtures
   c.include ZendeskAPI::Fixtures

--- a/spec/live/topic_spec.rb
+++ b/spec/live/topic_spec.rb
@@ -1,6 +1,18 @@
 require 'core/spec_helper'
 
-describe ZendeskAPI::Topic do
+RSpec.describe ZendeskAPI::Topic do
+  before :all do
+    VCR.configure do |c|
+      @previous_allow_http_connections = c.allow_http_connections_when_no_cassette?
+      c.allow_http_connections_when_no_cassette = true
+    end
+    client.topics.fetch!.map(&:destroy!)
+  ensure
+    VCR.configure do |c|
+      c.allow_http_connections_when_no_cassette = @previous_allow_http_connections
+    end
+  end
+
   def valid_attributes
     {
       :name => "My Topic",

--- a/spec/live/topic_spec.rb
+++ b/spec/live/topic_spec.rb
@@ -1,12 +1,13 @@
 require 'core/spec_helper'
 
 RSpec.describe ZendeskAPI::Topic do
+  # Cleanup topics (:delete_after doesn't work here)
   before :all do
     VCR.configure do |c|
       @previous_allow_http_connections = c.allow_http_connections_when_no_cassette?
       c.allow_http_connections_when_no_cassette = true
     end
-    client.topics.fetch!.map(&:destroy!)
+    client.topics.fetch!.reject { |t| t == @topic }.map(&:destroy!)
   ensure
     VCR.configure do |c|
       c.allow_http_connections_when_no_cassette = @previous_allow_http_connections


### PR DESCRIPTION
Proof this is working: https://github.com/zendesk/zendesk_api_client_rb/actions/runs/4695301392/jobs/8324339290?pr=533

See how there's one failure, then the single spec re-runs green.