### PR TITLE
HTTPX Faraday adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Upcoming changes
+- _Unofficial_ support for [httpx](https://rubygems.org/gems/httpx)
 
 ## v2.0.1
 

--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -26,7 +26,7 @@ module ZendeskAPI
   # The top-level class that handles configuration and connection to the Zendesk API.
   # Can also be used as an accessor to resource collections.
   class Client
-    GZIP_EXCEPTIONS = [:em_http, :httpclient]
+    GZIP_EXCEPTIONS = [:em_http, :httpclient, :httpx]
 
     # @return [Configuration] Config instance
     attr_reader :config


### PR DESCRIPTION
Which uses GZIP by default, so it it needs exclusion in Faraday.

See the original work in this pr https://github.com/zendesk/zendesk_api_client_rb/pull/486

With many thanks to @es.