### PR TITLE
RED-1497 Ruby Client CBP by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,6 @@ Layout/MultilineOperationIndentation:
 
 Metrics:
   Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false

--- a/lib/zendesk_api.rb
+++ b/lib/zendesk_api.rb
@@ -3,5 +3,6 @@ module ZendeskAPI; end
 require 'faraday'
 require 'faraday/multipart'
 
+require 'zendesk_api/helpers'
 require 'zendesk_api/core_ext/inflection'
 require 'zendesk_api/client'

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -188,9 +188,8 @@ module ZendeskAPI
       elsif association && association.options.parent && association.options.parent.new_record?
         return (@resources = [])
       end
-      path_query_link = (@query || path)
 
-      get_resources(path_query_link)
+      get_resources(@query || path)
     end
 
     def fetch(*args)
@@ -250,6 +249,7 @@ module ZendeskAPI
         clear_cache
         @options["page"] = @options["page"].to_i + 1
       elsif (@query = @next_page)
+        # Send _only_ url param "?after=token" to get the next page
         @options.page&.delete("before")
         fetch(true)
       else
@@ -267,6 +267,7 @@ module ZendeskAPI
         clear_cache
         @options["page"] -= 1
       elsif (@query = @prev_page)
+        # Send _only_ url param "?before=token" to get the prev page
         @options.page&.delete("after")
         fetch(true)
       else
@@ -405,13 +406,7 @@ module ZendeskAPI
 
       while (bang ? fetch! : fetch)
         each do |resource|
-          arguments = [resource, @options["page"] || 1]
-
-          if block.arity >= 0
-            arguments = arguments.take(block.arity)
-          end
-
-          block.call(*arguments)
+          block.call(resource, @options["page"] || 1)
         end
 
         last_page? ? break : self.next

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -344,7 +344,7 @@ module ZendeskAPI
     end
 
     def more_results?(response)
-      ![nil, false, '', {}, []].include?(response["meta"]) && response["meta"]["has_more"]
+      Helpers.present?(response["meta"]) && response["meta"]["has_more"]
     end
     alias_method :has_more_results?, :more_results? # For backward compatibility with 1.33.0 and 1.34.0
 

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -368,7 +368,7 @@ module ZendeskAPI
 
     private
 
-    def response_is_cbp?(body)
+    def cbp_response?(body)
       body["meta"] && body["links"]
     end
 
@@ -380,7 +380,7 @@ module ZendeskAPI
       @count = (body["count"] || @resources.size).to_i
       @next_page, @prev_page = page_links(body)
 
-      if response_is_cbp?(body)
+      if cbp_response?(body)
         @options.page.after = body["meta"]["after_cursor"]
         @options.page.before = body["meta"]["before_cursor"]
       elsif @next_page =~ /page=(\d+)/

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -3,10 +3,11 @@ require 'zendesk_api/resources'
 require 'zendesk_api/search'
 
 module ZendeskAPI
-  DEFAULT_PAGE_SIZE = 100
   # Represents a collection of resources. Lazily loaded, resources aren't
   # actually fetched until explicitly needed (e.g. #each, {#fetch}).
   class Collection
+    DEFAULT_PAGE_SIZE = 100
+
     include ZendeskAPI::Sideloading
 
     # Options passed in that are automatically converted from an array to a comma-separated list.

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -349,15 +349,11 @@ module ZendeskAPI
     end
     alias_method :has_more_results?, :more_results? # For backward compatibility with 1.33.0 and 1.34.0
 
-    def get_response_body(link)
-      @client.connection.send("get", link).body
-    end
-
     def get_next_page_data(original_response_body)
       link = original_response_body["links"]["next"]
       result_key = @resource_class.model_key || "results"
       while link
-        response = get_response_body(link)
+        response = @client.connection.send("get", link).body
 
         original_response_body[result_key] = original_response_body[result_key] + response[result_key]
 
@@ -459,7 +455,7 @@ module ZendeskAPI
 
     def get_response(path)
       @error = nil
-      @response = @client.connection.send(@verb || "get", path) do |req|
+      @client.connection.send(@verb || "get", path) do |req|
         opts = @options.delete_if { |_, v| v.nil? }
 
         req.params.merge!(:include => @includes.join(",")) if @includes.any?

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -285,7 +285,7 @@ module ZendeskAPI
     # * If there is a prev_page url cached, it executes a fetch on that url and returns the results.
     # * Otherwise, returns an empty array.
     def prev
-      if @options["page"] && @options["page"] > 1
+      if !@options["page"].is_a?(Hash) && @options["page"].to_i > 1
         clear_cache
         @options["page"] -= 1
       elsif (@query = @prev_page)

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -344,7 +344,7 @@ module ZendeskAPI
     private
 
     def cbp_response?(body)
-      body["meta"] && body["links"]
+      !!(body["meta"] && body["links"])
     end
 
     def intentional_obp_request?

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -478,9 +478,7 @@ module ZendeskAPI
       body = response_body.dup
       results = body.delete(@resource_class.model_key) || body.delete("results")
 
-      unless results
-        raise ZendeskAPI::Error::ClientError, "Expected #{@resource_class.model_key} or 'results' in response keys: #{body.keys.inspect}"
-      end
+      assert_results(results, body)
 
       @resources = results.map do |res|
         wrap_resource(res)
@@ -493,9 +491,7 @@ module ZendeskAPI
       body = response_body.dup
       results = body.delete(@resource_class.model_key) || body.delete("results")
 
-      unless results
-        raise ZendeskAPI::Error::ClientError, "Expected #{@resource_class.model_key} or 'results' in response keys: #{body.keys.inspect}"
-      end
+      assert_results(results, body)
 
       @resources = results.map do |res|
         wrap_resource(res)
@@ -552,6 +548,11 @@ module ZendeskAPI
       unless response_body.is_a?(Hash)
         raise ZendeskAPI::Error::NetworkError, @response.env
       end
+    end
+
+    def assert_results(results, body)
+      return if results
+      raise ZendeskAPI::Error::ClientError, "Expected #{@resource_class.model_key} or 'results' in response keys: #{body.keys.inspect}"
     end
   end
 end

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -245,7 +245,7 @@ module ZendeskAPI
     # * If there is a next_page url cached, it executes a fetch on that url and returns the results.
     # * Otherwise, returns an empty array.
     def next
-      if @options["page"] && !@options["page"].is_a?(Hash)
+      if @options["page"] && !cbp_request?
         clear_cache
         @options["page"] = @options["page"].to_i + 1
       elsif (@query = @next_page)
@@ -263,7 +263,7 @@ module ZendeskAPI
     # * If there is a prev_page url cached, it executes a fetch on that url and returns the results.
     # * Otherwise, returns an empty array.
     def prev
-      if !@options["page"].is_a?(Hash) && @options["page"].to_i > 1
+      if !cbp_request? && @options["page"].to_i > 1
         clear_cache
         @options["page"] -= 1
       elsif (@query = @prev_page)
@@ -348,8 +348,12 @@ module ZendeskAPI
       !!(body["meta"] && body["links"])
     end
 
+    def cbp_request?
+      @options["page"].is_a?(Hash)
+    end
+
     def intentional_obp_request?
-      Helpers.present?(@options["page"]) && !@options["page"].is_a?(SilentMash)
+      Helpers.present?(@options["page"]) && !cbp_request?
     end
 
     def get_resources(path_query_link)

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -271,6 +271,7 @@ module ZendeskAPI
         clear_cache
         @options["page"] = @options["page"].to_i + 1
       elsif (@query = @next_page)
+        @options.page&.delete("before")
         fetch(true)
       else
         clear_cache
@@ -287,6 +288,7 @@ module ZendeskAPI
         clear_cache
         @options["page"] -= 1
       elsif (@query = @prev_page)
+        @options.page&.delete("after")
         fetch(true)
       else
         clear_cache
@@ -378,8 +380,10 @@ module ZendeskAPI
       @count = (body["count"] || @resources.size).to_i
       @next_page, @prev_page = page_links(body)
 
-      # code below is for OBP responses, only
-      if @next_page =~ /page=(\d+)/
+      if response_is_cbp?(body)
+        @options.page.after = body["meta"]["after_cursor"]
+        @options.page.before = body["meta"]["before_cursor"]
+      elsif @next_page =~ /page=(\d+)/
         @options["page"] = $1.to_i - 1
       elsif @prev_page =~ /page=(\d+)/
         @options["page"] = $1.to_i + 1

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -370,7 +370,7 @@ module ZendeskAPI
     end
 
     def intentional_obp_request?
-      @options.page? && @options.page.is_a?(Numeric)
+      Helpers.present?(@options["page"]) && !@options["page"].is_a?(SilentMash)
     end
 
     def set_page_and_count(body)
@@ -378,8 +378,8 @@ module ZendeskAPI
       @next_page, @prev_page = page_links(body)
 
       if cbp_response?(body)
-        @options.page.after = body["meta"]["after_cursor"]
-        @options.page.before = body["meta"]["before_cursor"]
+        @options["page"]["after"] = body["meta"]["after_cursor"]
+        @options["page"]["before"] = body["meta"]["before_cursor"]
       elsif @next_page =~ /page=(\d+)/
         @options["page"] = $1.to_i - 1
       elsif @prev_page =~ /page=(\d+)/

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -472,9 +472,7 @@ module ZendeskAPI
     end
 
     def handle_cursor_search_export_response(response_body)
-      unless response_body.is_a?(Hash)
-        raise ZendeskAPI::Error::NetworkError, @response.env
-      end
+      assert_valid_response_body(response_body)
 
       response_body = get_next_page_data(response_body) if more_results?(response_body)
 
@@ -491,9 +489,7 @@ module ZendeskAPI
     end
 
     def handle_response(response_body)
-      unless response_body.is_a?(Hash)
-        raise ZendeskAPI::Error::NetworkError, @response.env
-      end
+      assert_valid_response_body(response_body)
 
       body = response_body.dup
       results = body.delete(@resource_class.model_key) || body.delete("results")
@@ -549,6 +545,12 @@ module ZendeskAPI
 
     def resource_methods
       @resource_methods ||= @resource_class.singleton_methods(false).map(&:to_sym)
+    end
+
+    def assert_valid_response_body(response_body)
+      unless response_body.is_a?(Hash)
+        raise ZendeskAPI::Error::NetworkError, @response.env
+      end
     end
   end
 end

--- a/lib/zendesk_api/helpers.rb
+++ b/lib/zendesk_api/helpers.rb
@@ -1,6 +1,10 @@
 module ZendeskAPI
   # @private
   module Helpers
+    def self.present?(value)
+      ![nil, false, " ", [], {}].include?(value)
+    end
+
     # From https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/modulize.rb
     # Converts a string to module name representation.
     #

--- a/lib/zendesk_api/helpers.rb
+++ b/lib/zendesk_api/helpers.rb
@@ -2,7 +2,7 @@ module ZendeskAPI
   # @private
   module Helpers
     def self.present?(value)
-      ![nil, false, " ", [], {}].include?(value)
+      ![nil, false, "", " ", [], {}].include?(value)
     end
 
     # From https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/modulize.rb

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -1026,10 +1026,10 @@ describe ZendeskAPI::Collection do
         expect do |b|
           silence_logger { subject.all(&b) }
         end.to yield_successive_args(
-          [ZendeskAPI::TestResource.new(client, :id => 1), anything],
-          [ZendeskAPI::TestResource.new(client, :id => 2), anything],
-          [ZendeskAPI::TestResource.new(client, :id => 3), anything],
-          [ZendeskAPI::TestResource.new(client, :id => 4), anything]
+          [ZendeskAPI::TestResource.new(client, id: 1), "after" => "after1", "before" => "before0", "size" => 100],
+          [ZendeskAPI::TestResource.new(client, id: 2), "after" => "after2", "before" => "before1", "size" => 100],
+          [ZendeskAPI::TestResource.new(client, id: 3), "after" => "after3", "before" => "before2", "size" => 100],
+          [ZendeskAPI::TestResource.new(client, id: 4), "after" => "after4", "before" => "before3", "size" => 100]
         )
       end
     end

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -5,9 +5,6 @@ describe ZendeskAPI::Collection do
     ZendeskAPI::Collection.new(client, ZendeskAPI::TestResource)
   end
 
-  # TODO!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  # TODO: pager, xxx, url
-
   describe "#prev" do
     let(:page1_cursor) { "111pg111" }
     let(:page2_cursor) { "222pg222" }
@@ -25,27 +22,11 @@ describe ZendeskAPI::Collection do
         "test_resources" => [{ "id" => 1 }, { "id" => 2 }]
       }
     end
-    # let :response_body_page2 do
-    #   {
-    #     "meta" => {
-    #       "has_more" => false,
-    #       "before_cursor" => page1_cursor,
-    #       "after_cursor" => nil
-    #     },
-    #     "links" => {
-    #       "prev" => "https://zen.com/test_resources.json?page[after]=#{page1_cursor}&page[size]=2",
-    #       "next" => nil
-    #     },
-    #     "test_resources" => [{ "id" => 3 }]
-    #   }
-    # end
 
     let(:response_page1) { double("response_page1", body: response_body_page1) }
-    # let(:response_page2) { double("response_page2", body: response_body_page2) }
 
     before do
       allow(subject).to receive(:get_response).with("test_resources").and_return(response_page1)
-      # allow(subject).to receive(:get_response).with("https://zen.com/test_resources.json?page[after]=222pg222&page[size]=2").and_return(response_page1)
     end
 
     context "when CBP is used" do
@@ -1003,15 +984,16 @@ describe ZendeskAPI::Collection do
   end
 
   describe "pagination behaviour" do
+    let(:page2_cursor) { "222pg222" }
     let(:cbp_response) do
       {
         "meta" => {
           "has_more" => true,
-          "after_cursor" => "xxx",
+          "after_cursor" => page2_cursor,
           "before_cursor" => nil
         },
         "links" => {
-          "next" => "https://test_resources.json?pager[after]=xxx&page[size]=100",
+          "next" => "https://test_resources.json?page[after]=#{page2_cursor}&page[size]=100",
           "prev" => nil
         },
         "test_resources" => [{ "id" => 1 }]
@@ -1029,13 +1011,13 @@ describe ZendeskAPI::Collection do
 
       it "tries to make a CBP request, setting the page[size] parameter" do
         subject.fetch
-        expect(subject.instance_variable_get(:@options)["page"]).to eq({ "size" => 100, "after" => "xxx", "before" => nil })
+        expect(subject.instance_variable_get(:@options)["page"]).to eq({ "size" => 100, "after" => page2_cursor, "before" => nil })
       end
 
       context "when per_page is given" do
         it "tries the CBP request with the given page size" do
           subject.per_page(22).fetch
-          expect(subject.instance_variable_get(:@options)["page"]).to eq({ "size" => 22, "after" => "xxx", "before" => nil })
+          expect(subject.instance_variable_get(:@options)["page"]).to eq({ "size" => 22, "after" => page2_cursor, "before" => nil })
         end
       end
     end

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -986,6 +986,19 @@ describe ZendeskAPI::Collection do
           expect(subject.instance_variable_get(:@options)["page"]).to eq({ "size" => 22, "after" => "xxx", "before" => nil })
         end
       end
+
+      describe "#prev" do
+        before do
+          allow(subject).to receive(:get_response).with("test_resources").and_return(cbp_success_response)
+        end
+
+        context "when CBP is used" do
+          it "goes prev" do
+            subject.fetch
+            subject.prev
+          end
+        end
+      end
     end
 
     context "when the endpoint does not support CBP" do

--- a/spec/core/helpers_spec.rb
+++ b/spec/core/helpers_spec.rb
@@ -1,0 +1,21 @@
+require 'core/spec_helper'
+
+RSpec.describe ZendeskAPI::Helpers do
+  describe "#present?" do
+    it "is false when nil, or empty" do
+      expect(described_class.present?(nil)).to be(false)
+      expect(described_class.present?("")).to be(false)
+      expect(described_class.present?(" ")).to be(false)
+      expect(described_class.present?([])).to be(false)
+      expect(described_class.present?({})).to be(false)
+    end
+
+    it "is true when there's something" do
+      expect(described_class.present?(1)).to be(true)
+      expect(described_class.present?(:a)).to be(true)
+      expect(described_class.present?("b")).to be(true)
+      expect(described_class.present?([:a])).to be(true)
+      expect(described_class.present?(c: 3)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION

Tries to make CBP requests when `page` is not specified. If the request raises an error it retries without the cbp specifics