### PR TITLE
Bump v3.0.0.rc1 - Default to CBP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Unreleased
 
-- _Unofficial_ support for [httpx](https://rubygems.org/gems/httpx)
+## v3.0.0.beta
+
+In this version, We are bringing Cursor Based Pagination (CBP) support to all supported endpoints. This is in line with the [limits announcement](https://support.zendesk.com/hc/en-us/articles/5591904358938-New-limits-for-offset-based-pagination) made by Zendesk to promote system reliability and also CBP usage.
+
+- `Collection#all` uses CBP by default instead of Offset Based Pagination (OBP). If an endpoint doesn't support CBP, then a new OBP request will be triggered automatically with the same parameters. This is managed by the library internally
+- `Collection#next and #prev` using CBP by default
+- The pagination behaviour of search and exports endpoint have not changed
+- We are adding support for [httpx](https://rubygems.org/gems/httpx). We will be monitoring the issues and feedback to determine if we continue the support and make it into a stable release
+
+**Notes:**
+
+- OBP support will be further limited in the Zendesk APIs and will be deprecated soon. We are working to ensure all Zendesk APIs support CBP and transition for the customers is smooth
+- The order of the returned results is different in CBP from OBP at times depending on the endpoint behaviour and support for ordering. Please note that any ordering was never hard-coded or built-in so it is not guaranteed. We recommend that you pick the relevant sort/order needed for your workflows and pass them explicitly when making the API call via the library
+- This is a Beta-release and we seek your feedback, experiences. Please open an issue or create a PR to help us work with you
 
 ## v2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-## v3.0.0.beta
+## v3.0.0.rc1
 
 In this version, We are bringing Cursor Based Pagination (CBP) support to all supported endpoints. This is in line with the [limits announcement](https://support.zendesk.com/hc/en-us/articles/5591904358938-New-limits-for-offset-based-pagination) made by Zendesk to promote system reliability and also CBP usage.
 
 - `Collection#all` uses CBP by default instead of Offset Based Pagination (OBP). If an endpoint doesn't support CBP, then a new OBP request will be triggered automatically with the same parameters. This is managed by the library internally
 - `Collection#next and #prev` using CBP by default
-- The pagination behaviour of search and exports endpoint have not changed
+- The pagination behaviour of search and export endpoint have not changed
 - We are adding support for [httpx](https://rubygems.org/gems/httpx). We will be monitoring the issues and feedback to determine if we continue the support and make it into a stable release
 
 **Notes:**

--- a/README.md
+++ b/README.md
@@ -431,9 +431,10 @@ bundle exec rubocop # Runs the lint (use `--fix` for autocorrect)
 
 ## Releasing a new gem version
 
+1. From updated master: `git checkout -b bump-vX.X.X`, according to [SemVer](https://semver.org)
 1. Ensure the CHANGELOG is correct and updated, this is your last opportunity
-2. Execute `bundle exec bump patch --tag`, or minor or major according to [SemVer](https://semver.org), this bumps the version in your local machine in the latest commit
-3. Push to GitHub `git push && git push origin vX.X.X`
+2. Execute `bundle exec bump patch --tag`, or minor or major, this bumps the version in your local machine in the latest commit
+3. Push to GitHub `git pull && git push origin vX.X.X`
 4. Raise a PR and get it approved and merged
 5. Post a message in Slack `#rest-api`, so advocacy are aware that we are going to release a new gem, just in case any customer complains about something related to the gem
 6. After 2 hours from the above message, you can [approve the release of the gem](https://github.com/zendesk/zendesk_api_client_rb/deployments/activity_log?environment=rubygems-publish)

--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "2.0.2"
+  VERSION = "3.0.0.rc1"
 end

--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
Release `v3.0.0.rc1` 

[Diff](https://github.com/zendesk/zendesk_api_client_rb/compare/v2.0.1...v3.0.0.rc1)

Ref. RED-1708