### PR TITLE
Bump v3.0.0

### DIFF
--- a/lib/zendesk_api/version.rb
+++ b/lib/zendesk_api/version.rb
@@ -1,3 +1,3 @@
 module ZendeskAPI
-  VERSION = "3.0.0.rc1"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
### Description

Bump to version 3.0.0 from 3.0.0 rc1

[Diff](https://github.com/zendesk/zendesk_api_client_rb/compare/v2.0.1...v3.0.0.rc1) is the same as the previous (rc1 version)