### PR TITLE
[RED-1820] Do not attempt CBP requests on specific endpoints

### DIFF
--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -356,10 +356,15 @@ module ZendeskAPI
       Helpers.present?(@options["page"]) && !cbp_request?
     end
 
+    def should_try_cbp?(path_query_link)
+      not_supported_endpoints = %w[show_many]
+      not_supported_endpoints.none? { |endpoint| path_query_link.end_with?(endpoint) }
+    end
+
     def get_resources(path_query_link)
       if intentional_obp_request?
         warn "Offset Based Pagination will be deprecated soon"
-      elsif @next_page.nil?
+      elsif @next_page.nil? && should_try_cbp?(path_query_link)
         @options_per_page_was = @options.delete("per_page")
         # Default to CBP by using the page param as a map
         @options.page = { size: (@options_per_page_was || DEFAULT_PAGE_SIZE) }

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -1004,6 +1004,17 @@ describe ZendeskAPI::Collection do
       double("response", body: cbp_response)
     end
 
+    context "when we know for sure that the endpoint does not support CBP" do
+      before do
+        stub_json_request(:get, %r{test_resources\/show_many}, json(:test_resources => [{ :id => 1 }]))
+      end
+
+      it "does not try to default to CBP" do
+        subject.show_many.fetch
+        expect(subject.instance_variable_get(:@options)["page"]).to be_nil
+      end
+    end
+
     context "when fetching a collection" do
       before do
         expect(subject).to receive(:get_response).with("test_resources").and_return(cbp_success_response)


### PR DESCRIPTION
### Description
This PR is an attempt to reduce the number of requests that could potentially return 400 responses. 
`show_many` is one endpoint which we should not attempt any kind of pagination.  