### PR TITLE
[RED-1821] Remove CBP attempt and specify endpoints that support CBP

### DIFF
--- a/lib/zendesk_api/client.rb
+++ b/lib/zendesk_api/client.rb
@@ -54,7 +54,8 @@ module ZendeskAPI
     end
 
     def respond_to?(method, *args)
-      ((cache = @resource_cache[method]) && cache[:class]) || !resource_class_for(method).nil? || super
+      cache = @resource_cache[method]
+      !!(cache.to_h[:class] || resource_class_for(method) || super)
     end
 
     # Returns the current user (aka me)
@@ -185,8 +186,8 @@ module ZendeskAPI
     private
 
     def resource_class_for(method)
-      klass_as_string = ZendeskAPI::Helpers.modulize_string(Inflection.singular(method.to_s.gsub(/\W/, '')))
-      ZendeskAPI::Association.class_from_namespace(klass_as_string)
+      resource_name = ZendeskAPI::Helpers.modulize_string(Inflection.singular(method.to_s.gsub(/\W/, '')))
+      ZendeskAPI::Association.class_from_namespace(resource_name)
     end
 
     def check_url

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -391,8 +391,14 @@ module ZendeskAPI
       @next_page, @prev_page = page_links(body)
 
       if cbp_response?(body)
-        @options["page"]["after"] = body["meta"]["after_cursor"]
-        @options["page"]["before"] = body["meta"]["before_cursor"]
+        @options.page = {} unless cbp_request?
+        # the line above means an intentional CBP request where page[size] is passed on the query
+        # this is to cater for CBP responses where we don't specify page[size] but the endpoint
+        # responds CBP by default. i.e  `client.trigger_categories.fetch`
+        @options.page.merge!(
+          after: body["meta"]["after_cursor"],
+          before: body["meta"]["before_cursor"]
+                             )
       elsif @next_page =~ /page=(\d+)/
         @options["page"] = $1.to_i - 1
       elsif @prev_page =~ /page=(\d+)/

--- a/lib/zendesk_api/collection.rb
+++ b/lib/zendesk_api/collection.rb
@@ -354,9 +354,9 @@ module ZendeskAPI
       @options.page = { size: (@options_per_page_was || DEFAULT_PAGE_SIZE) }
     end
 
+    # CBP requests look like: `/resources?page[size]=100`
+    # OBP requests look like: `/resources?page=2`
     def cbp_request?
-      # CBP requests look like: `/resources?page[size]=100`
-      # OBP requests look like: `/resources?page=2`
       @options["page"].is_a?(Hash)
     end
 

--- a/lib/zendesk_api/resources.rb
+++ b/lib/zendesk_api/resources.rb
@@ -378,6 +378,8 @@ module ZendeskAPI
     extend UpdateMany
     extend DestroyMany
 
+    CBP_ACTIONS = %w[tickets].freeze
+
     # Unlike other attributes, "comment" is not a property of the ticket,
     # but is used as a "comment on save", so it should be kept unchanged,
     # See https://github.com/zendesk/zendesk_api_client_rb/issues/321

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -563,7 +563,7 @@ describe ZendeskAPI::Collection do
         stub_json_request(:get, %r{test_resources}, json(cbp_response))
       end
 
-      it "should set the next and previous pages and cursors" do
+      it "sets the next and previous pages and cursors" do
         subject.fetch
         expect(subject.instance_variable_get(:@next_page)).to eq("next_page")
         expect(subject.instance_variable_get(:@prev_page)).to eq("previous_page")

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -543,6 +543,34 @@ describe ZendeskAPI::Collection do
         expect(subject.fetch(true)).to be_empty
       end
     end
+
+    context "when the request returns a Cursor Based Pagination type of response" do
+      let(:cbp_response) do
+        {
+          "meta" => {
+            "has_more" => true,
+            "after_cursor" => 'after_cursor',
+            "before_cursor" => 'before_cursor'
+          },
+          "links" => {
+            "next" => "next_page",
+            "prev" => "previous_page"
+          },
+          "test_resources" => [{ "id" => 1 }]
+        }
+      end
+      before do
+        stub_json_request(:get, %r{test_resources}, json(cbp_response))
+      end
+
+      it "should set the next and previous pages and cursors" do
+        subject.fetch
+        expect(subject.instance_variable_get(:@next_page)).to eq("next_page")
+        expect(subject.instance_variable_get(:@prev_page)).to eq("previous_page")
+        expect(subject.options.page.after).to eq("after_cursor")
+        expect(subject.options.page.before).to eq("before_cursor")
+      end
+    end
   end
 
   context "save" do

--- a/spec/live/ticket_spec.rb
+++ b/spec/live/ticket_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe ZendeskAPI::Ticket do
     end
   end
 
+  describe "#show_many" do
+    let(:how_many_tickets) { 10 }
+    before do
+      VCR.use_cassette("get_tickets_show_many") do
+        @tickets = client.tickets.per_page(how_many_tickets).fetch
+      end
+
+      VCR.use_cassette("tickets_show_many_with_ids") do
+        @tickets_from_show_many = client.tickets.show_many(ids: @tickets.map(&:id)).fetch
+      end
+    end
+
+    it "returns the correct number of tickets" do
+      expect(@tickets_from_show_many.count).to eq(how_many_tickets)
+      expect(@tickets.map(&:id).sort).to eq(@tickets_from_show_many.map(&:id).sort)
+    end
+  end
+
   describe "#attributes_for_save" do
     let :ticket do
       described_class.new(instance_double(ZendeskAPI::Client), status: :new)


### PR DESCRIPTION
### Description

Removes the `try CBP and retry with OBP if the first request fails` approach
Implements CBP on specific endpoints for the `Resource` ( whitelist approach )
Refactoring to improve readability in `collection.rb` 