### PR TITLE
Remove the duplicate method named `self.new_from_response`

### DIFF
--- a/lib/zendesk_api/resource.rb
+++ b/lib/zendesk_api/resource.rb
@@ -76,14 +76,6 @@ module ZendeskAPI
       @attributes.clear_changes unless new_record?
     end
 
-    def self.new_from_response(client, response, includes = nil)
-      new(client).tap do |resource|
-        resource.handle_response(response)
-        resource.set_includes(resource, includes, response.body) if includes
-        resource.attributes.clear_changes
-      end
-    end
-
     # Passes the method onto the attributes hash.
     # If the attributes are nested (e.g. { :tickets => { :id => 1 } }), passes the method onto the nested hash.
     def method_missing(*args, &block)


### PR DESCRIPTION
Small PR to remove the duplicate method named `self.new_from_response`. The class method already exists [here](https://github.com/zendesk/zendesk_api_client_rb/blob/master/lib/zendesk_api/resource.rb#L43#L50).

Risk: Low