### PR TITLE
Add tests with Ruby 3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - "jruby-9.4"
     steps:
       - name: Checkout code

--- a/spec/core/resource_spec.rb
+++ b/spec/core/resource_spec.rb
@@ -455,7 +455,12 @@ describe ZendeskAPI::Resource do
 
   context "#inspect" do
     it "should display nicely" do
-      expect(ZendeskAPI::User.new(client, :foo => :bar).inspect).to eq("#<ZendeskAPI::User {\"foo\"=>:bar}>")
+      expected_user_representation = if RUBY_VERSION >= "3.4"
+        "#<ZendeskAPI::User {\"foo\" => :bar}>"
+      else
+        "#<ZendeskAPI::User {\"foo\"=>:bar}>"
+      end
+      expect(ZendeskAPI::User.new(client, :foo => :bar).inspect).to eq(expected_user_representation)
     end
   end
 


### PR DESCRIPTION
Adds tests with Ruby 3.4.

Updates a spec that checks User#inspect output to work with the new Hash#inspect behaviour: https://github.com/ruby/ruby/pull/10924