### PR TITLE
Adding notifications support for various lifecycle conditions

### DIFF
--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -54,6 +54,9 @@ module ZendeskAPI
     # specify if you want a (network layer) exception to elicit a retry
     attr_accessor :retry_on_exception
 
+    # specify if you want instrumentation to be used
+    attr_accessor :instrumentation
+
     def initialize
       @client_options = {}
       @use_resource_cache = true

--- a/lib/zendesk_api/middleware/request/retry.rb
+++ b/lib/zendesk_api/middleware/request/retry.rb
@@ -15,44 +15,79 @@ module ZendeskAPI
           @logger = options[:logger]
           @error_codes = (options.key?(:retry_codes) && options[:retry_codes]) ? options[:retry_codes] : DEFAULT_ERROR_CODES
           @retry_on_exception = (options.key?(:retry_on_exception) && options[:retry_on_exception]) ? options[:retry_on_exception] : false
+          @instrumentation = options[:instrumentation]
         end
 
         def call(env)
+          # Duplicate env for retries but keep attempt counter persistent
           original_env = env.dup
+          original_env[:call_attempt] = (env[:call_attempt] || 0)
+
           exception_happened = false
+          response = nil
+
           if @retry_on_exception
             begin
               response = @app.call(env)
-            rescue => e
+            rescue => ex
               exception_happened = true
+              exception = ex
             end
           else
+            # Allow exceptions to propagate normally when not retrying
             response = @app.call(env)
           end
 
-          if exception_happened || @error_codes.include?(response.env[:status])
-
-            if exception_happened
-              seconds_left = DEFAULT_RETRY_AFTER.to_i
-              @logger&.warn "An exception happened, waiting #{seconds_left} seconds... #{e}"
-            else
-              seconds_left = (response.env[:response_headers][:retry_after] || DEFAULT_RETRY_AFTER).to_i
-            end
-
-            @logger&.warn "You have been rate limited. Retrying in #{seconds_left} seconds..."
-
-            seconds_left.times do |i|
-              sleep 1
-              time_left = seconds_left - i
-              @logger&.warn "#{time_left}..." if time_left > 0 && time_left % 5 == 0
-            end
-
-            @logger&.warn ""
-
-            @app.call(original_env)
-          else
-            response
+          if exception_happened
+            original_env[:call_attempt] += 1
+            seconds_left = DEFAULT_RETRY_AFTER.to_i
+            @logger&.warn "An exception happened, waiting #{seconds_left} seconds... #{exception}"
+            instrument_retry(original_env, "exception", seconds_left)
+            sleep_with_logging(seconds_left)
+            return @app.call(original_env)
           end
+
+          # Retry once if response has a retryable error code
+          if response && @error_codes.include?(response.env[:status])
+            original_env[:call_attempt] += 1
+            seconds_left = (response.env[:response_headers][:retry_after] || DEFAULT_RETRY_AFTER).to_i
+            @logger&.warn "You may have been rate limited. Retrying in #{seconds_left} seconds..."
+            instrument_retry(original_env, (response.env[:status] == 429) ? "rate_limited" : "server_error", seconds_left)
+            sleep_with_logging(seconds_left)
+            response = @app.call(original_env)
+          end
+
+          response
+        end
+
+        private
+
+        def instrument_retry(env, reason, delay)
+          return unless @instrumentation
+
+          begin
+            @instrumentation.instrument(
+              "zendesk.retry",
+              {
+                attempt: env[:call_attempt],
+                endpoint: env[:url]&.path,
+                method: env[:method],
+                reason: reason,
+                delay: delay
+              }
+            )
+          rescue => e
+            @logger&.debug("zendesk.retry instrumentation failed: #{e.message}")
+          end
+        end
+
+        def sleep_with_logging(seconds_left)
+          seconds_left.times do |i|
+            sleep 1
+            time_left = seconds_left - i
+            @logger&.warn "#{time_left}..." if time_left > 0 && time_left % 5 == 0
+          end
+          @logger&.warn "" if seconds_left > 0
         end
       end
     end

--- a/lib/zendesk_api/middleware/response/zendesk_request_event.rb
+++ b/lib/zendesk_api/middleware/response/zendesk_request_event.rb
@@ -1,0 +1,72 @@
+require "faraday/response"
+
+module ZendeskAPI
+  module Middleware
+    module Response
+      # @private
+      class ZendeskRequestEvent < Faraday::Middleware
+        def initialize(app, options = {})
+          super(app)
+          @instrumentation = options[:instrumentation]
+          @logger = options[:logger]
+        end
+
+        def call(env)
+          return @app.call(env) unless instrumentation
+
+          start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          @app.call(env).on_complete do |response_env|
+            stop_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+            begin
+              instrument_request(response_env, start_time, stop_time)
+              instrument_rate_limit(response_env)
+            rescue => e
+              logger&.debug("Instrumentation failed: #{e.message}")
+            end
+          end
+        end
+
+        private
+
+        attr_reader :instrumentation, :logger
+
+        def instrument_request(response_env, start_time, stop_time)
+          duration_ms = (stop_time - start_time) * 1000.0
+
+          payload = {
+            duration: duration_ms,
+            endpoint: response_env[:url]&.path,
+            method: response_env[:method],
+            status: response_env[:status]
+          }
+
+          instrumentation.instrument("zendesk.request", payload)
+        end
+
+        def instrument_rate_limit(response_env)
+          status = response_env[:status]
+          return unless status && status < 500
+
+          headers = response_env[:response_headers]
+          remaining, limit, reset = headers&.values_at(
+            "X-Rate-Limit-Remaining",
+            "X-Rate-Limit",
+            "X-Rate-Limit-Reset"
+          )
+          return if [remaining, limit, reset].all?(&:nil?)
+
+          payload = {
+            endpoint: response_env[:url]&.path,
+            status: status,
+            remaining: remaining,
+            limit: limit,
+            reset: reset
+          }
+
+          instrumentation.instrument("zendesk.rate_limit", payload)
+        end
+      end
+    end
+  end
+end

--- a/spec/core/middleware/request/etag_cache_spec.rb
+++ b/spec/core/middleware/request/etag_cache_spec.rb
@@ -1,3 +1,5 @@
+require "core/spec_helper"
+
 describe ZendeskAPI::Middleware::Request::EtagCache do
   it "caches" do
     client.config.cache.size = 1
@@ -14,6 +16,65 @@ describe ZendeskAPI::Middleware::Request::EtagCache do
 
     %w[content_encoding content_type content_length etag].each do |header|
       expect(response.headers[header]).to eq(first_response.headers[header])
+    end
+  end
+
+  context "instrumentation" do
+    let(:instrumenter) { TestInstrumenter.new }
+    let(:cache) { ZendeskAPI::LRUCache.new(5) }
+    let(:middleware) do
+      ZendeskAPI::Middleware::Request::EtagCache.new(
+        ->(env) { Faraday::Response.new(env) },
+        cache: cache,
+        instrumentation: instrumenter
+      )
+    end
+    let(:env) do
+      {
+        url: URI("https://example.zendesk.com/api/v2/blergh"),
+        method: :get,
+        request_headers: {},
+        response_headers: {"Etag" => "x"},
+        status: nil,
+        body: {"x" => 1},
+        response_body: {"x" => 1}
+      }
+    end
+
+    it "instruments cache miss on first request" do
+      env[:status] = 200
+      middleware.call(env).on_complete { |_e| }
+
+      cache_events = instrumenter.find_events("zendesk.cache_miss")
+      expect(cache_events.size).to eq(1)
+
+      event = cache_events.first[:payload]
+      expect(event[:endpoint]).to eq("/api/v2/blergh")
+      expect(event[:status]).to eq(200)
+    end
+
+    it "instruments cache hit on 304 response" do
+      cache.write(middleware.cache_key(env), env)
+      env[:status] = 304
+      middleware.call(env).on_complete { |_e| }
+
+      cache_events = instrumenter.find_events("zendesk.cache_hit")
+      expect(cache_events.size).to eq(1)
+
+      event = cache_events.first[:payload]
+      expect(event[:endpoint]).to eq("/api/v2/blergh")
+      expect(event[:status]).to eq(304)
+    end
+
+    it "does not crash when instrumentation is nil" do
+      no_instrumentation_middleware = ZendeskAPI::Middleware::Request::EtagCache.new(
+        ->(env) { Faraday::Response.new(env) },
+        cache: cache,
+        instrumentation: nil
+      )
+
+      env[:status] = 200
+      expect { no_instrumentation_middleware.call(env).on_complete { |_e| } }.not_to raise_error
     end
   end
 end

--- a/spec/core/middleware/request/retry_spec.rb
+++ b/spec/core/middleware/request/retry_spec.rb
@@ -116,4 +116,36 @@ describe ZendeskAPI::Middleware::Request::Retry do
       end
     end
   end
+
+  context "with instrumentation on retry" do
+    let(:instrumenter) { TestInstrumenter.new }
+
+    before do
+      client.config.instrumentation = instrumenter
+      stub_request(:get, %r{instrumented}).to_return(status: 429, headers: {retry_after: 1}).to_return(status: 200)
+    end
+
+    it "instruments retry attempts with correct payload" do
+      client.connection.get("instrumented")
+
+      retry_events = instrumenter.find_events("zendesk.retry")
+      expect(retry_events.size).to eq(1)
+
+      event = retry_events.first[:payload]
+      expect(event[:attempt]).to eq(1)
+      expect(event[:endpoint]).to eq("/api/v2/instrumented")
+      expect(event[:method]).to eq(:get)
+      expect(event[:reason]).to eq("rate_limited")
+      expect(event[:delay]).to be >= 0
+    end
+
+    it "does not instrument when no retry occurs" do
+      stub_request(:get, %r{no_retry}).to_return(status: 200)
+
+      client.connection.get("no_retry")
+
+      retry_events = instrumenter.find_events("zendesk.retry")
+      expect(retry_events).to be_empty
+    end
+  end
 end

--- a/spec/core/middleware/response/zendesk_request_event_spec.rb
+++ b/spec/core/middleware/response/zendesk_request_event_spec.rb
@@ -1,0 +1,111 @@
+require "core/spec_helper"
+require "faraday"
+require "zendesk_api/middleware/response/zendesk_request_event"
+
+RSpec.describe ZendeskAPI::Middleware::Response::ZendeskRequestEvent do
+  let(:app) { ->(env) { Faraday::Response.new(env) } }
+  let(:logger) { Logger.new(File::NULL) }
+  let(:instrumenter) { TestInstrumenter.new }
+  let(:middleware) { described_class.new(app, instrumentation: instrumenter, logger: logger) }
+  let(:response_headers) do
+    {
+      "X-Rate-Limit-Remaining" => "10",
+      "X-Rate-Limit" => "100",
+      "X-Rate-Limit-Reset" => "1234567890"
+    }
+  end
+  let(:env) do
+    {
+      url: URI("https://example.zendesk.com/api/v2/tickets"),
+      method: :get,
+      status: status,
+      response_headers: response_headers
+    }
+  end
+
+  context "when the response status is less than 500" do
+    let(:status) { 200 }
+
+    it "instruments both zendesk.request and zendesk.rate_limit" do
+      middleware.call(env).on_complete { |_response_env| }
+
+      request_events = instrumenter.find_events("zendesk.request")
+      expect(request_events.size).to eq(1)
+
+      request_payload = request_events.first[:payload]
+      expect(request_payload[:duration]).to be > 0
+      expect(request_payload[:endpoint]).to eq("/api/v2/tickets")
+      expect(request_payload[:method]).to eq(:get)
+      expect(request_payload[:status]).to eq(200)
+
+      rate_limit_events = instrumenter.find_events("zendesk.rate_limit")
+      expect(rate_limit_events.size).to eq(1)
+
+      rate_limit_payload = rate_limit_events.first[:payload]
+      expect(rate_limit_payload[:endpoint]).to eq("/api/v2/tickets")
+      expect(rate_limit_payload[:status]).to eq(200)
+      expect(rate_limit_payload[:remaining]).to eq("10")
+      expect(rate_limit_payload[:limit]).to eq("100")
+      expect(rate_limit_payload[:reset]).to eq("1234567890")
+    end
+  end
+
+  context "when the response status is 500 or greater" do
+    let(:status) { 500 }
+
+    it "instruments only zendesk.request, not zendesk.rate_limit" do
+      middleware.call(env).on_complete { |_response_env| }
+
+      request_events = instrumenter.find_events("zendesk.request")
+      expect(request_events.size).to eq(1)
+
+      request_payload = request_events.first[:payload]
+      expect(request_payload[:status]).to eq(500)
+
+      rate_limit_events = instrumenter.find_events("zendesk.rate_limit")
+      expect(rate_limit_events).to be_empty
+    end
+  end
+
+  context "when rate limit headers are missing" do
+    let(:status) { 200 }
+    let(:response_headers) { {} }
+
+    it "instruments request but not rate_limit" do
+      middleware.call(env).on_complete { |_response_env| }
+
+      request_events = instrumenter.find_events("zendesk.request")
+      expect(request_events.size).to eq(1)
+
+      rate_limit_events = instrumenter.find_events("zendesk.rate_limit")
+      expect(rate_limit_events).to be_empty
+    end
+  end
+
+  context "when instrumentation is nil" do
+    let(:status) { 200 }
+    let(:middleware) { described_class.new(app, instrumentation: nil, logger: logger) }
+
+    it "does not raise an error" do
+      expect { middleware.call(env).on_complete { |_response_env| } }.not_to raise_error
+    end
+
+    it "does not instrument any events" do
+      middleware.call(env).on_complete { |_response_env| }
+
+      expect(instrumenter.events).to be_empty
+    end
+  end
+
+  context "when instrumentation raises an error" do
+    let(:status) { 200 }
+
+    it "rescues the error and logs it" do
+      allow(instrumenter).to receive(:instrument).and_raise("Instrumentation error")
+
+      expect(logger).to receive(:debug)
+
+      middleware.call(env).on_complete { |_response_env| }
+    end
+  end
+end

--- a/spec/core/spec_helper.rb
+++ b/spec/core/spec_helper.rb
@@ -164,3 +164,24 @@ VCR.configure do |c|
   # In development, this helps debugging.
   c.allow_http_connections_when_no_cassette = true
 end
+
+class TestInstrumenter
+  attr_reader :events
+
+  def initialize
+    @events = []
+  end
+
+  def instrument(name, payload = {})
+    @events << {name: name, payload: payload}
+    yield if block_given?
+  end
+
+  def find_events(name)
+    @events.select { |e| e[:name] == name }
+  end
+
+  def clear
+    @events.clear
+  end
+end


### PR DESCRIPTION
Allows applications to configure any instrumentation backend that responds to `#instrument(event_name, payload)`, e.g. `ActiveSupport::Notifications`

## Usage

```ruby
ZendeskAPI.configure do |config|
  config.instrumentation = ActiveSupport::Notifications
end
```
## Instrumentation Events

### `zendesk.request`
- When: All requests (emitted regardless of status code)
- Payload: `duration` (ms), `endpoint`, `method`, `status`

### `zendesk.rate_limit`
- When: Status < 500 AND rate limit headers present
- Not emitted for: 5xx errors, missing headers
- Payload: `endpoint`, `status`, `remaining`, `limit`, `reset`
- Note: Includes successful requests and 4xx errors when rate limit headers are present

### `zendesk.cache_hit`
- When: `304 Not Modified` served from cache
- Requires: Cache enabled, matching ETag
- Payload: `endpoint`, `status` (304)

### `zendesk.cache_miss`
- When: `200 OK` with ETag cached for future requests
- Requires: Cache enabled, ETag header present
- Payload: `endpoint`, `status` (200)

### `zendesk.retry`
- When: Before retry sleep (`429`, `503`, or exception)
- Requires: Retry enabled; exceptions need `retry_on_exception: true`
- Payload: `attempt` (starts at 1), `endpoint`, `method`, `delay` (seconds), `reason`
- Reasons: `"rate_limited"` (429), `"server_error"` (503), `"exception"` (network failures)

## Key assumptions/decisions
- Users must supply their own compatible `config.instrumentation`, this lib does not pull in `activesupport`
- `duration` reports round-trip time including network call and response processing middleware
- Rate limit events only for status < `500` (client/rate limit errors)
- Request events emitted for all requests (not filtered by status)
- Instrumentation failures logged at debug level or silently swallowed