### PR TITLE
use new account in live specs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,9 @@ jobs:
     name: Spec live
     if: github.repository == 'zendesk/zendesk_api_client_rb'
     env:
-      SPEC_LIVE_USERNAME: ${{ secrets.SPEC_LIVE_USERNAME }}
-      SPEC_LIVE_PASSWORD: ${{ secrets.SPEC_LIVE_PASSWORD }}
-      SPEC_LIVE_ZENDESK_HOST: ${{ secrets.SPEC_LIVE_ZENDESK_HOST }}
+      SPEC_LIVE_USERNAME: ${{ secrets.SPEC_LIVE_USERNAME_NEW }}
+      SPEC_LIVE_PASSWORD: ${{ secrets.SPEC_LIVE_PASSWORD_NEW }}
+      SPEC_LIVE_ZENDESK_HOST: ${{ secrets.SPEC_LIVE_ZENDESK_HOST_NEW }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Test](https://github.com/zendesk/zendesk_api_client_rb/workflows/Test/badge.svg)](https://github.com/zendesk/zendesk_api_client_rb/actions/workflows/main.yml?query=branch%3Amaster)
 [![Gem Version](https://badge.fury.io/rb/zendesk_api.svg)](https://badge.fury.io/rb/zendesk_api)
-[![Code Climate](https://codeclimate.com/github/zendesk/zendesk_api_client_rb.svg)](https://codeclimate.com/github/zendesk/zendesk_api_client_rb)
 
 ## Documentation
 
@@ -42,7 +41,7 @@ Add it to your Gemfile
 gem "zendesk_api"
 ```
 
-Then `bundle` as usual.
+Then `bundle install` as usual.
 
 ## Configuration
 

--- a/spec/core/middleware/response/parse_iso_dates_spec.rb
+++ b/spec/core/middleware/response/parse_iso_dates_spec.rb
@@ -8,13 +8,7 @@ describe ZendeskAPI::Middleware::Response::ParseIsoDates do
     response
   end
 
-  let(:parsed){
-    if RUBY_VERSION > "1.9"
-      "2012-02-01 13:14:15 UTC"
-    else
-      "Wed Feb 01 13:14:15 UTC 2012"
-    end
-  }
+  let(:parsed) { "2012-02-01 13:14:15 UTC" }
 
   it "should parse dates" do
     expect(fake_response('{"x":"2012-02-01T13:14:15Z"}').body["x"].to_s).to eq(parsed)

--- a/spec/live/Readme.md
+++ b/spec/live/Readme.md
@@ -1,8 +1,14 @@
- - Make an empty account (company name Z3N, email <something>@zendesk.com, so it can be filtered)
- - Create an Admin user (ownwer cannot verify user identities) and ensure this new user has an organization. Then, add the new user credentials to `spec/fixtures/credentials.yml`
- - Mark 1 ticket as solved, change end-users email to on your can receive, copy ticket url, login as end-user (do not just assume identity), rate it
+If you are a Zendesk engineer, you can find the currently used test account in Pandora by “zendesk_api_client” tag (or pool).
+
+In case you want to create a test account from scratch:
+ - Create an empty account (again, use Pandora if you are a Zendesk engineer). Set company name to Z3N.
+ - Create a second Admin user (don’t use the owner account in tests: owners cannot verify user identities). Ensure this new user has an organization. Then, add the new user credentials to `spec/fixtures/credentials.yml`
+ - Activate Help Center
+ - Enable “Allow customers to rate tickets” in People → Configuration → End users → Satisfaction 
+ - Mark 1 ticket as solved, change end-users email to one you can receive, copy ticket url, login as end-user (do not just assume identity), rate it. You might need to check that request page layout includes Satisfaction (in Theming Center). Alternatively, receive an email from the “Request customer satisfaction rating” automation (change its parameters to send notifications earlier than in 24 hours)
+ - Create a user field in Admin Center → People → Configuration → User fields
+ - In `article_spec.rb`, replace `permission_group_id`. Use `curl` to list permission groups for this account: `curl https://{subdomain}.zendesk.com/api/v2/guide/permission_groups.json -u {email_address}:{password}`.
+ - After running `article_spec.rb` once, log in as an end user (it can be the same as above) and upvote the “What are these sections and articles doing here?” article.
+ - Add photo to user profile of that end user.
  - Create a new ticket and cc "zendesk-api-client-ruby-end-user-#{client.config.username}" (run tests once to create this user)
- - Suspend "zendesk-api-client-ruby-anonymous-#{client.config.username}" account, so tickets created by this account go to suspended
  - Ensure you allow admins to set up user password (or `POST /api/v2/users/{user_id}/password.json` will fail). You can check this in the admin centre > security > advanced
- - Go to Account > Localization and ensure you add `Spanish` to the list of additional languages. The `variant_spec` needs to create some items using spanish locale.
- - Ensure the authenticated agent is the assigned to the main fixture ticket at `spec/fixtures/zendesk.rb`, or the `activities_spec` won't get any update, and thus, will fail.

--- a/spec/live/article_spec.rb
+++ b/spec/live/article_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ZendeskAPI::Article, :delete_after do
 
   describe "creating articles within a section" do
     def valid_attributes
-      { :name => "My Article", user_segment_id: nil, permission_group_id: 2801272, title: "My super article" }
+      { :name => "My Article", user_segment_id: nil, permission_group_id: "9903096093850", title: "My super article" }
     end
 
     let(:section_article) do

--- a/spec/live/ticket_spec.rb
+++ b/spec/live/ticket_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe ZendeskAPI::Ticket do
   it_should_be_deletable
   it_should_be_readable :tickets
   it_should_be_readable user, :requested_tickets
-  it_should_be_readable current_user, :assigned_tickets, create: true
-  it_should_be_readable agent, :ccd_tickets, create: true
+  it_should_be_readable current_user, :assigned_tickets
+  it_should_be_readable agent, :ccd_tickets
   it_should_be_readable organization, :tickets
 
   describe "#create" do

--- a/spec/live/trigger_spec.rb
+++ b/spec/live/trigger_spec.rb
@@ -3,7 +3,7 @@ require 'core/spec_helper'
 describe ZendeskAPI::Trigger, :delete_after do
   def valid_attributes
     {
-      :category_id => "3",
+      :category_id => "9903501961242",
       :title => "my test trigger",
       :conditions => {
         :all => [{ :field => "status", :operator => "is", :value => "open" }]


### PR DESCRIPTION
Switches to a different test account in live specs (provisioned with Pandora), updates account setup instructions, cleans up a few unrelated things.